### PR TITLE
Commit Julienne code and applications.

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -14,14 +14,14 @@ ifdef BYTE
 CODE = -DBYTE
 else ifdef NIBBLE
 CODE = -DNIBBLE
-else 
+else
 CODE = -DBYTERLE
 endif
 
 #compilers
 ifdef CILK
 PCC = g++
-PCFLAGS = -fcilkplus -lcilkrts -O2 -DCILK $(INTT) $(INTE) $(CODE) $(PD)
+PCFLAGS = -std=c++14 -fcilkplus -lcilkrts -O2 -DCILK $(INTT) $(INTE) $(CODE) $(PD)
 PLFLAGS = -fcilkplus -lcilkrts
 
 else ifdef MKLROOT
@@ -30,21 +30,21 @@ PCFLAGS = -O3 -DCILKP $(INTT) $(INTE) $(CODE) $(PD)
 
 else ifdef OPENMP
 PCC = g++
-PCFLAGS = -fopenmp -O3 -DOPENMP $(INTT) $(INTE) $(CODE) $(PD)
+PCFLAGS = -std=c++14 -fopenmp -O3 -DOPENMP $(INTT) $(INTE) $(CODE) $(PD)
 
 else
 PCC = g++
-PCFLAGS = -O2 $(INTT) $(INTE) $(CODE) $(PD)
+PCFLAGS = -std=c++14 -O2 $(INTT) $(INTE) $(CODE) $(PD)
 endif
 
-COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h quickSort.h blockRadixSort.h transpose.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
+COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h index_map.h maybe.h sequence.h edgeMap_utils.h binary_search.h quickSort.h blockRadixSort.h transpose.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
 
 ALL= encoder BFS BC BellmanFord Components Radii PageRank PageRankDelta BFSCC BFS-Bitvector KCore MIS Triangle CF
 
 all: $(ALL)
 
 % : %.C $(COMMON)
-	$(PCC) $(PCFLAGS) -o $@ $< 
+	$(PCC) $(PCFLAGS) -o $@ $<
 
 $(COMMON):
 	ln -s ../ligra/$@ .

--- a/apps/bucketing/DeltaStepping.C
+++ b/apps/bucketing/DeltaStepping.C
@@ -1,0 +1,96 @@
+#define WEIGHTED 1
+#include <cmath>
+#include "ligra.h"
+#include "index_map.h"
+#include "bucket.h"
+
+constexpr uintE TOP_BIT = ((uintE)INT_E_MAX) + 1;
+constexpr uintE VAL_MASK = INT_E_MAX;
+
+struct Visit_F {
+  array_imap<uintE> dists;
+  Visit_F(array_imap<uintE>& _dists) : dists(_dists) { }
+
+  inline Maybe<uintE> update(const uintE& s, const uintE& d, const intE& w) {
+    uintE oval = dists.s[d];
+    uintE dist = oval | TOP_BIT, n_dist = (dists.s[s] | TOP_BIT) + w;
+    if (n_dist < dist) {
+      if (!(oval & TOP_BIT)) { // First visitor
+        dists[d] = n_dist;
+        return Maybe<uintE>(oval);
+      }
+      dists[d] = n_dist;
+    }
+    return Maybe<uintE>();
+  }
+
+  inline Maybe<uintE> updateAtomic(const uintE& s, const uintE& d, const intE& w) {
+    uintE oval = dists.s[d];
+    uintE dist = oval | TOP_BIT;
+    uintE n_dist = (dists.s[s] | TOP_BIT) + w;
+    if (n_dist < dist) {
+      if (!(oval & TOP_BIT) && CAS(&(dists[d]), oval, n_dist)) { // First visitor
+        return Maybe<uintE>(oval);
+      }
+      writeMin(&(dists[d]), n_dist);
+    }
+    return Maybe<uintE>();
+  }
+
+  inline bool cond(const uintE& d) const { return true; }
+};
+
+template <class vertex>
+void DeltaStepping(graph<vertex>& G, uintE src, uintE delta, size_t num_buckets=128) {
+  auto V = G.V; size_t n = G.n, m = G.m;
+  auto dists = array_imap<uintE>(n, [&] (size_t i) { return INT_E_MAX; });
+  dists[src] = 0;
+
+  auto get_bkt = [&] (const uintE& dist) -> const uintE {
+    return (dist == INT_E_MAX) ? UINT_E_MAX : (dist / delta); };
+  auto get_ring = [&] (const size_t& v) -> const uintE {
+    auto d = dists[v];
+    return (d == INT_E_MAX) ? UINT_E_MAX : (d / delta); };
+  auto b = make_buckets(n, get_ring, increasing, num_buckets);
+
+  auto apply_f = [&] (const uintE v, uintE& oldDist) -> void {
+    uintE newDist = dists.s[v] & VAL_MASK;
+    dists.s[v] = newDist; // Remove the TOP_BIT in the distance.
+    // Compute the previous bucket and new bucket for the vertex.
+    uintE prev_bkt = get_bkt(oldDist), new_bkt = get_bkt(newDist);
+    bucket_dest dest = b.get_bucket(prev_bkt, new_bkt);
+    oldDist = dest; // write back
+  };
+
+  auto bkt = b.next_bucket();
+  while (bkt.id != b.null_bkt) {
+    auto active = bkt.identifiers;
+    // The output of the edgeMap is a vertexSubsetData<uintE> where the value
+    // stored with each vertex is its original distance in this round
+    auto res = edgeMapData<uintE>(G, active, Visit_F(dists), G.m/20, DENSE_FORWARD,
+                                  output | sparse_no_filter);
+    vertexMap(res, apply_f);
+    b.update_buckets(res.get_fn_repr(), res.size());
+    res.del(); active.del();
+    bkt = b.next_bucket();
+  }
+}
+
+template <class vertex>
+void Compute(graph<vertex>& GA, commandLine P) {
+  uintE src = P.getOptionLongValue("-src",0);
+  uintE delta = P.getOptionLongValue("-delta",1);
+  size_t num_buckets = P.getOptionLongValue("-nb", 128);
+  if (num_buckets != (1 << pbbs::log2_up(num_buckets))) {
+    cout << "Please specify a number of buckets that is a power of two" << endl;
+    exit(-1);
+  }
+  cout << "### Application: Delta-Stepping" << endl;
+  cout << "### Graph: " << P.getArgument(0) << endl;
+  cout << "### Workers: " << getWorkers() << endl;
+  cout << "### Buckets: " << num_buckets << endl;
+  cout << "### n: " << GA.n << endl;
+  cout << "### m: " << GA.m << endl;
+  cout << "### delta = " << delta << endl;
+  DeltaStepping(GA, src, delta, num_buckets);
+}

--- a/apps/bucketing/KCore.C
+++ b/apps/bucketing/KCore.C
@@ -1,0 +1,58 @@
+#include "ligra.h"
+#include "index_map.h"
+#include "bucket.h"
+#include "edgeMapReduce.h"
+
+template <class vertex>
+array_imap<uintE> KCore(graph<vertex>& GA, size_t num_buckets=128) {
+  const size_t n = GA.n; const size_t m = GA.m;
+  auto D = array_imap<uintE>(n, [&] (size_t i) { return GA.V[i].getOutDegree(); });
+
+  auto em = EdgeMap<uintE, vertex>(GA, make_tuple(UINT_E_MAX, 0), (size_t)GA.m/5);
+  auto b = make_buckets(n, D, increasing, num_buckets);
+
+  size_t finished = 0;
+  while (finished != n) {
+    auto bkt = b.next_bucket();
+    auto active = bkt.identifiers;
+    uintE k = bkt.id;
+    finished += active.size();
+
+    auto apply_f = [&] (const tuple<uintE, uintE>& p) -> const Maybe<tuple<uintE, uintE> > {
+      uintE v = std::get<0>(p), edgesRemoved = std::get<1>(p);
+      uintE deg = D.s[v];
+      if (deg > k) {
+        uintE new_deg = max(deg - edgesRemoved, k);
+        D.s[v] = new_deg;
+        uintE bkt = b.get_bucket(deg, new_deg);
+        return wrap(v, bkt);
+      }
+      return Maybe<tuple<uintE, uintE> >();
+    };
+
+    vertexSubsetData<uintE> moved = em.template edgeMapCount<uintE>(active, apply_f);
+    b.update_buckets(moved.get_fn_repr(), moved.size());
+    moved.del(); active.del();
+  }
+  return D;
+}
+
+template <class vertex>
+void Compute(graph<vertex>& GA, commandLine P) {
+  size_t num_buckets = P.getOptionLongValue("-nb", 128);
+  if (num_buckets != (1 << pbbs::log2_up(num_buckets))) {
+    cout << "Number of buckets must be a power of two." << endl;
+    exit(-1);
+  }
+  cout << "### Application: k-core" << endl;
+  cout << "### Graph: " << P.getArgument(0) << endl;
+  cout << "### Workers: " << getWorkers() << endl;
+  cout << "### Buckets: " << num_buckets << endl;
+  cout << "### n: " << GA.n << endl;
+  cout << "### m: " << GA.m << endl;
+
+  auto cores = KCore(GA, num_buckets);
+  uintE mc = 0;
+  for (size_t i=0; i < GA.n; i++) { mc = std::max(mc, cores[i]); }
+  cout << "### Max core: " << mc << endl;
+}

--- a/apps/bucketing/KCoreSerial.C
+++ b/apps/bucketing/KCoreSerial.C
@@ -1,0 +1,113 @@
+#include "ligra.h"
+
+// Linear-work sequential implementation of the BZ coreness alg
+// Modified code from https://github.com/athomo/kcore/blob/master/src/KCoreWG_BZ.java
+
+struct decompress_f {
+  intT* deg;
+  intT* pos;
+  intT* vert;
+  intT* bin;
+  decompress_f(intT* _deg, intT* _pos, intT* _vert, intT* _bin) : deg(_deg), pos(_pos), vert(_vert), bin(_bin) {}
+
+  inline bool update (const uintE& v, const uintE& u) {
+    if (deg[u] > deg[v]) {
+      intT du = deg[u]; intT pu = pos[u];
+      intT pw = bin[du]; intT w = vert[pw];
+      if (u != w) {
+        pos[u] = pw; vert[pu] = w;
+        pos[w] = pu; vert[pw] = u;
+      }
+      bin[du]++;
+      deg[u]--;
+    }
+    return false;
+  }
+
+  inline bool updateAtomic (uintE s, uintE d) {
+    update(s, d);
+  }
+
+  // Condition is checked in update.
+  inline bool cond (uintE d) { return true; }
+};
+
+template <class vertex>
+array_imap<intT> KCore(graph<vertex>& G, bool printCores=false) {
+  size_t n = G.n, m = G.m;
+
+  uintE md = 0;
+  for(size_t v=0; v<n; v++) {
+    md = max(md, (uintE)G.V[v].getOutDegree());
+  }
+
+  array_imap<intT> vert(n);
+  array_imap<intT> pos(n);
+  array_imap<intT> deg(n);
+  array_imap<intT> bin(md+1);
+
+  for (size_t d=0; d<=md; d++) {
+    bin[d] = 0;
+  }
+  for (size_t v=0; v<n; v++) {
+    intT d_v = G.V[v].getOutDegree();
+    deg[v] = d_v;
+    bin[d_v]++;
+  }
+
+  // Scan for positions.
+  size_t start = 0;
+  for (size_t d=0; d<=md; d++) {
+    intT num = bin[d];
+    bin[d] = start;
+    start += num;
+  }
+
+  // Bin-sort.
+  for (size_t v=0; v<n; v++) {
+    pos[v] = bin[deg[v]];
+    vert[pos[v]] = v;
+    bin[deg[v]]++;
+  }
+
+  // Recover bin[].
+  for (size_t d=md; d>=1; d--) {
+    bin[d] = bin[d-1];
+  }
+  bin[0] = 0;
+
+  auto df = decompress_f(deg.s, pos.s, vert.s, bin.s);
+
+  // Main algorithm.
+  auto vs = vertexSubset(n, (uintE)0);
+  for (size_t i = 0; i < n; i++) {
+    intT v = vert[i];  // Smallest degree vertex in the remaining graph.
+    vs.s[0] = v;
+    edgeMap(G, vs, df, -1, DENSE, no_output);
+  }
+  vs.del();
+
+  if (printCores) {
+    for (size_t i=0; i<n; i++) {
+      cout << deg[i] << endl;
+    }
+  }
+  size_t mc = 0;
+  for (size_t i=0; i<n; i++) {
+    mc = max(mc, (size_t)deg[i]);
+  }
+  cout << "### max core: " << mc << endl;
+
+  return deg;
+}
+
+template <class vertex>
+void Compute(graph<vertex>& GA, commandLine P) {
+  bool printCores = P.getOptionValue("-p");
+  cout << "### application: k-core-serial" << endl;
+  cout << "### graph: " << P.getArgument(0) << endl;
+  cout << "### workers: " << getWorkers() << endl;
+  cout << "### n: " << GA.n << endl;
+  cout << "### m: " << GA.m << endl;
+  auto cores = KCore(GA, printCores);
+}

--- a/apps/bucketing/Makefile
+++ b/apps/bucketing/Makefile
@@ -1,0 +1,59 @@
+ifdef LONG
+INTT = -DLONG
+endif
+
+ifdef EDGELONG
+INTE = -DEDGELONG
+endif
+
+ifdef PD
+PD = -DPD
+endif
+
+ifdef BYTE
+CODE = -DBYTE
+else ifdef NIBBLE
+CODE = -DNIBBLE
+else
+CODE = -DBYTERLE
+endif
+
+#compilers
+ifdef CILK
+PCC = g++
+PCFLAGS = -std=c++1y -fcilkplus -lcilkrts -O3 -DCILK $(INTT) $(INTE) $(CODE) $(PD) $(FLAGS)
+PLFLAGS = -fcilkplus -lcilkrts
+
+else ifdef MKLROOT
+PCC = icpc
+PCFLAGS = -O3 -DCILKP $(INTT) $(INTE) $(CODE) $(PD)
+
+else ifdef OPENMP
+PCC = g++
+PCFLAGS = -fopenmp -O3 -DOPENMP $(INTT) $(INTE) $(CODE) $(PD)
+
+else
+PCC = g++
+PCFLAGS = -O2 $(INTT) $(INTE) $(CODE) $(PD)
+endif
+
+COMMON= ligra.h edgeMap_utils.h index_map.h sequence.h maybe.h binary_search.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h quickSort.h blockRadixSort.h transpose.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
+
+ALL= DeltaStepping KCore KCoreSerial SetCover
+
+all: $(ALL)
+
+% : %.C $(COMMON)
+	$(PCC) $(PCFLAGS) -o $@ $<
+
+$(COMMON):
+	ln -s ../../ligra/$@ .
+
+.PHONY : clean
+
+clean :
+	rm -f *.o $(ALL)
+
+cleansrc :
+	rm -f *.o $(ALL)
+	rm $(COMMON)

--- a/apps/bucketing/SetCover.C
+++ b/apps/bucketing/SetCover.C
@@ -1,0 +1,113 @@
+#include "ligra.h"
+#include "index_map.h"
+#include "bucket.h"
+#include "edgeMapReduce.h"
+
+constexpr uintE TOP_BIT = ((uintE)INT_E_MAX) + 1;
+constexpr uintE COVERED = ((uintE)INT_E_MAX) - 1;
+constexpr double epsilon = 0.01;
+constexpr double x = 1.0/log(1.0 + epsilon);
+auto max_f = [] (uintE x, uintE y) { return std::max(x,y); };
+
+struct Visit_Elms {
+  uintE* elms;
+  Visit_Elms(uintE* _elms) : elms(_elms) { }
+  inline bool updateAtomic(const uintE& s, const uintE& d) {
+    uintE oval = elms[d];
+    writeMin(&(elms[d]), s);
+    return false;
+  }
+  inline bool update(const uintE& s, const uintE& d) { return updateAtomic(s, d); }
+  inline bool cond(const uintE& d) const { return elms[d] != COVERED; }
+};
+
+template <class vertex>
+dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
+  timer t; t.start();
+  auto Elms = array_imap<uintE>(G.n, [&] (size_t i) { return UINT_E_MAX; });
+  auto D = array_imap<uintE>(G.n, [&] (size_t i) { return G.V[i].getOutDegree(); });
+  auto get_bucket_clamped = [&] (size_t deg) -> uintE { return (deg == 0) ? UINT_E_MAX : (uintE)floor(x * log((double) deg)); };
+  auto bucket_f = [&] (size_t i) { return get_bucket_clamped(D(i)); };
+  auto b = make_buckets(G.n, bucket_f, decreasing, num_buckets);
+  size_t rounds = 0;
+  dyn_arr<uintE> cover = dyn_arr<uintE>();
+  while (true) {
+    auto bkt = b.next_bucket();
+    auto active = bkt.identifiers; size_t cur_bkt = bkt.id;
+    if (cur_bkt == b.null_bkt) { break; }
+
+    // 1. sets -> elements (Pack out sets and update their degree)
+    auto pack_predicate = [&] (const uintE& u, const uintE& ngh) { return Elms[ngh] != COVERED; };
+    auto pack_apply = [&] (uintE v, size_t ct) { D[v] = ct; };
+    auto packed_vtxs = edgeMapFilter(G, active, pack_predicate, output | pack_edges);
+    vertexMap(packed_vtxs, pack_apply);
+
+    // Calculate the sets which still have sufficient degree (degree >= threshold)
+    size_t threshold = ceil(pow(1.0+epsilon,cur_bkt));
+    auto above_threshold = [&] (const uintE& v, const uintE& deg) { return deg >= threshold; };
+    auto still_active = vertexFilter2<uintE>(packed_vtxs, above_threshold);
+    packed_vtxs.del();
+
+    // 2. sets -> elements (writeMin to acquire neighboring elements)
+    edgeMap(G, still_active, Visit_Elms(Elms.s), -1, DENSE_FORWARD, no_output);
+
+    // 3. sets -> elements (count and add to cover if enough elms were won)
+    const size_t low_threshold = std::max((size_t)ceil(pow(1.0+epsilon,cur_bkt-1)), (size_t)1);
+    auto won_ngh_f = [&] (const uintE& u, const uintE& v) -> bool { return Elms[v] == u; };
+    auto threshold_f = [&] (const uintE& v, const uintE& numWon) {
+      if (numWon >= low_threshold) D[v] |= TOP_BIT;
+    };
+    auto activeAndCts = edgeMapFilter(G, still_active, won_ngh_f);
+    vertexMap(activeAndCts, threshold_f);
+    auto inCover = vertexFilter2(activeAndCts, [&] (const uintE& v, const uintE& numWon) {
+        return numWon >= low_threshold; });
+    cover.copyInF([&] (uintE i) { return inCover.vtx(i); }, inCover.size());
+    inCover.del(); activeAndCts.del();
+
+    // 4. sets -> elements (Sets that joined the cover mark their neighboring
+    // elements as covered. Sets that didn't reset any acquired elements)
+    auto reset_f = [&] (const uintE& u, const uintE& v) -> bool {
+      if (Elms[v] == u) {
+        if (D(u) & TOP_BIT) Elms[v] = COVERED;
+        else Elms[v] = UINT_E_MAX;
+      }
+    };
+    edgeMap(G, still_active, EdgeMap_F<decltype(reset_f)>(reset_f), -1, DENSE_FORWARD, no_output);
+
+    // Rebucket the active sets. Ignore those that joined the cover.
+    active.toSparse();
+    auto f = [&] (size_t i) -> Maybe<tuple<uintE, uintE> > {
+      const uintE v = active.vtx(i);
+      const uintE dv = D(v);
+      uintE bkt = UINT_E_MAX;
+      if (!(dv & TOP_BIT))
+        bkt = b.get_bucket(cur_bkt, get_bucket_clamped(dv));
+      return Maybe<tuple<uintE, uintE> >(make_tuple(v, bkt));
+    };
+    b.update_buckets(f, active.size());
+    active.del(); still_active.del();
+    rounds++;
+  }
+  t.stop(); t.reportTotal("Running time: ");
+
+  auto elm_cov = make_in_imap<uintE>(G.n, [&] (uintE v) { return (uintE)(Elms[v] == COVERED); });
+  size_t elms_cov = pbbs::reduce_add(elm_cov);
+  cout << "|V| = " << G.n << " |E| = " << G.m << endl;
+  cout << "|cover|: " << cover.size << endl;
+  cout << "Rounds: " << rounds << endl;
+  cout << "Num_uncovered = " << (G.n - elms_cov) << endl;
+  return cover;
+}
+
+template <class vertex>
+void Compute(graph<vertex>& GA, commandLine P) {
+  size_t num_buckets = P.getOptionLongValue("-nb", 128);
+  cout << "### Application: set-cover" << endl;
+  cout << "### Graph: " << P.getArgument(0) << endl;
+  cout << "### Workers: " << getWorkers() << endl;
+  cout << "### Buckets: " << num_buckets << endl;
+  cout << "### n: " << GA.n << endl;
+  cout << "### m: " << GA.m << endl;
+  auto cover = SetCover(GA, num_buckets);
+  cover.del();
+}

--- a/apps/bucketing/bucket.h
+++ b/apps/bucketing/bucket.h
@@ -1,0 +1,345 @@
+#pragma once
+
+#include <limits>
+#include <tuple>
+
+#include "dyn_arr.h"
+#include "maybe.h"
+#include "parallel.h"
+#include "vertexSubset.h"
+
+#define CACHE_LINE_S 64
+
+using namespace std;
+
+typedef uintE bucket_id;
+typedef uintE bucket_dest;
+
+enum bucket_order {
+  decreasing,
+  increasing
+};
+
+struct bucket {
+  size_t id;
+  size_t num_filtered;
+  vertexSubset identifiers;
+  bucket(size_t _id, vertexSubset _identifiers) :
+    id(_id), identifiers(_identifiers) { }
+};
+
+template <class D>
+struct buckets {
+  public:
+    using id_dyn_arr = dyn_arr<uintE>;
+
+    const uintE null_bkt = std::numeric_limits<uintE>::max();
+
+    // Create a bucketing structure.
+    //   n : the number of identifiers
+    //   d : map from identifier -> bucket
+    //   order : the order to iterate over the buckets
+    //   total_buckets: the total buckets to materialize
+    //
+    //   For an identifier i:
+    //   d(i) is the bucket currently containing i
+    //   d(i) = UINT_E_MAX if i is not in any bucket
+    buckets(size_t _n,
+            D _d,
+            bucket_order _order,
+            size_t _total_buckets) :
+        n(_n), d(_d), order(_order),
+        open_buckets(_total_buckets-1), total_buckets(_total_buckets),
+        cur_bkt(0), max_bkt(_total_buckets), num_elms(0) {
+      // Initialize array consisting of the materialized buckets.
+      bkts = pbbs::new_array<id_dyn_arr>(total_buckets);
+
+      // Set the current range being processed based on the order.
+      if (order == increasing) {
+        auto imap = make_in_imap<uintE>(n, [&] (size_t i) { return d(i); });
+        auto min = [] (uintE x, uintE y) { return std::min(x, y); };
+        size_t min_b = pbbs::reduce(imap, min);
+        cur_range = min_b / open_buckets;
+      } else if (order == decreasing) {
+        auto imap = make_in_imap<uintE>(n, [&] (size_t i) {
+            return (d(i) == null_bkt) ? 0 : d(i); });
+        auto max = [] (uintE x, uintE y) { return std::max(x,y); };
+        size_t max_b = pbbs::reduce(imap, max);
+        cur_range = (max_b + open_buckets) / open_buckets;
+      } else {
+        cout << "Unknown order: " << order
+             << ". Must be one of {increasing, decreasing}" << endl;
+        abort();
+      }
+
+      // Update buckets with all (id, bucket) pairs. Identifiers with bkt =
+      // null_bkt are ignored by update_buckets.
+      auto get_id_and_bkt = [&] (uintE i) -> Maybe<tuple<uintE, uintE> > {
+        uintE bkt = _d(i);
+        if (bkt != null_bkt) {
+          bkt = to_range(bkt);
+        }
+        return Maybe<tuple<uintE, uintE> >(make_tuple(i, bkt));
+      };
+      update_buckets(get_id_and_bkt, n);
+    }
+
+    // Returns the next non-empty bucket from the bucket structure. The return
+    // value's bkt_id is null_bkt when no further buckets remain.
+    inline bucket next_bucket() {
+      while (!curBucketNonEmpty() && num_elms > 0) {
+        _next_bucket();
+      }
+      if (num_elms == 0) {
+        size_t bkt_num = null_bkt; // no buckets remain
+        vertexSubset vs(n);
+        return bucket(bkt_num, vs);
+      }
+      return get_cur_bucket();
+    }
+
+    // Computes a bucket_dest for an identifier moving from bucket_id prev to
+    // bucket_id next.
+    inline bucket_dest get_bucket(const bucket_id& prev,
+                                  const bucket_id& next) const {
+      uintE pb = to_range(prev);
+      uintE nb = to_range(next);
+      if ((nb != null_bkt) && (
+          (prev == null_bkt) ||
+          (pb != nb) ||
+          (nb == cur_bkt))) {
+        return nb;
+      }
+      return null_bkt;
+    }
+
+    // Updates k identifiers in the bucket structure. The i'th identifier and
+    // its bucket_dest are given by F(i).
+    template <class F>
+    inline size_t update_buckets(F f, size_t k) {
+       size_t num_blocks = k / 4096;
+       int num_threads = getWorkers();
+       if (k < 4096 || num_threads == 1) {
+         return update_buckets_seq(f, k);
+       }
+
+       size_t ne_before = num_elms;
+
+       size_t block_bits = pbbs::log2_up(num_blocks);
+       num_blocks = 1 << block_bits;
+       size_t block_size = (k + num_blocks - 1) / num_blocks;
+
+       uintE* hists = pbbs::new_array_no_init<uintE>((num_blocks+1) * total_buckets * CACHE_LINE_S);
+       uintE* outs = pbbs::new_array_no_init<uintE>((num_blocks+1) * total_buckets);
+
+       // 1. Compute per-block histograms
+       parallel_for_1(size_t i=0; i<num_blocks; i++) {
+         size_t s = i * block_size;
+         size_t e = min(s + block_size, k);
+         uintE* hist = &(hists[i*total_buckets]);
+
+         for (size_t j=0; j<total_buckets; j++) { hist[j] = 0; }
+         for (size_t j=s; j<e; j++) {
+           auto m = f(j);
+           bucket_dest b = std::get<1>(m.t);
+           if (m.exists && b != null_bkt) {
+             hist[b]++;
+           }
+         }
+       }
+
+      // 2. Aggregate histograms into a single histogram.
+      auto get = [&] (size_t i) {
+        size_t col = i % num_blocks;
+        size_t row = i / num_blocks;
+        return hists[col*total_buckets + row];
+      };
+
+      auto in_map = make_in_imap<uintE>(num_blocks*total_buckets, get);
+      auto out_map = array_imap<uintE>(outs, num_blocks*total_buckets);
+
+      size_t sum = pbbs::scan_add(in_map, out_map);
+      outs[num_blocks*total_buckets] = sum;
+
+      // 3. Resize buckets based on the summed histogram.
+      for (size_t i=0; i<total_buckets; i++) {
+        size_t num_inc = outs[(i+1)*num_blocks] - outs[i*num_blocks];
+        bkts[i].resize(num_inc);
+        num_elms += num_inc;
+      }
+
+      // 4. Compute the starting offsets for each block.
+      parallel_for(size_t i=0; i<total_buckets; i++) {
+        size_t start = outs[i*num_blocks];
+        for (size_t j=0; j<num_blocks; j++) {
+          hists[(i*num_blocks + j)*CACHE_LINE_S] = outs[i*num_blocks + j] - start;
+        }
+      }
+
+      // 5. Iterate over blocks again. Insert (id, bkt) into bkt[hists[bkt]]
+      // and increment hists[bkt].
+      parallel_for_1 (size_t i=0; i<num_blocks; i++) {
+         size_t s = i * block_size;
+         size_t e = min(s + block_size, k);
+         // our buckets are now spread out, across outs
+         for (size_t j=s; j<e; j++) {
+           auto m = f(j);
+           uintE v = std::get<0>(m.t);
+           bucket_dest b = std::get<1>(m.t);
+           if (m.exists && b != null_bkt) {
+             size_t ind = hists[(b*num_blocks + i)*CACHE_LINE_S];
+             bkts[b].insert(v, ind);
+             hists[(b*num_blocks + i)*CACHE_LINE_S]++;
+           }
+         }
+      }
+
+      // 6. Finally, update the size of each bucket.
+      for (size_t i=0; i<total_buckets; i++) {
+        size_t num_inc = outs[(i+1)*num_blocks] - outs[i*num_blocks];
+        size_t& m = bkts[i].size;
+        m += num_inc;
+      }
+
+      free(hists); free(outs);
+      return num_elms - ne_before;
+    }
+
+  private:
+    const bucket_order order;
+    id_dyn_arr* bkts;
+    size_t cur_bkt;
+    size_t max_bkt;
+    size_t cur_range;
+    D d;
+    size_t n; // total number of identifiers in the system
+    size_t num_elms;
+    size_t open_buckets;
+    size_t total_buckets;
+
+    template <class F>
+    inline size_t update_buckets_seq(F& f, size_t n) {
+      size_t ne_before = num_elms;
+      for (size_t i=0; i<n; i++) {
+        auto m = f(i);
+        bucket_dest bkt = std::get<1>(m.t);
+        if (m.exists && bkt != null_bkt) {
+          bkts[bkt].resize(1);
+          insert_in_bucket(bkt, std::get<0>(m.t));
+          num_elms++;
+        }
+      }
+      return num_elms - ne_before;
+    }
+
+    inline void insert_in_bucket(size_t b, intT val) {
+      uintE* dst = bkts[b].A;
+      intT size = bkts[b].size;
+      dst[size] = val;
+      bkts[b].size += 1;
+    }
+
+    inline bool curBucketNonEmpty() {
+      return bkts[cur_bkt].size > 0;
+    }
+
+    inline void unpack() {
+      size_t m = bkts[open_buckets].size;
+      auto _d = d;
+      auto tmp = array_imap<uintE>(m);
+      uintE* A = bkts[open_buckets].A;
+      parallel_for(size_t i=0; i<m; i++) {
+        tmp[i] = A[i];
+      }
+      if (order == increasing) {
+        cur_range++; // increment range
+      } else {
+        cur_range--;
+      }
+      bkts[open_buckets].size = 0; // reset size
+
+      auto g = [&] (uintE i) -> Maybe<tuple<uintE, uintE> > {
+        uintE v = tmp[i];
+        uintE bkt = to_range(_d(v));
+        return Maybe<tuple<uintE, uintE> >(make_tuple(v, bkt));
+      };
+
+      if (m != num_elms) {
+        cout << "m = " << m << " num_elms = " << num_elms << endl;
+        cur_bkt = 0;
+        cout << "curBkt = " << get_cur_bucket_num() << endl;
+        cout << "mismatch" << endl;
+        for (size_t i=0; i<total_buckets; i++) {
+          cout << bkts[i].size << endl;
+          if (bkts[i].size > 0) {
+            for (size_t j=0; j<bkts[i].size; j++) {
+              cout << bkts[i].A[j] << endl;
+              cout << "deg = " << _d(bkts[i].A[j]) << endl;
+              cout << "bkt = " << ((cur_range+1)*(open_buckets) - i - 1) << endl;
+            }
+          }
+        }
+        exit(0);
+      }
+      size_t updated = update_buckets(g, m);
+      size_t num_in_range = updated - bkts[open_buckets].size;
+      num_elms -= m;
+    }
+
+    inline void _next_bucket() {
+      cur_bkt++;
+      if (cur_bkt == open_buckets) {
+        unpack();
+        cur_bkt = 0;
+      }
+    }
+
+    // increasing: [cur_range*open_buckets, (cur_range+1)*open_buckets)
+    // decreasing: [(cur_range-1)*open_buckets, cur_range*open_buckets)
+    inline bucket_id to_range(uintE bkt) const {
+      if (order == increasing) {
+        if (bkt < cur_range*open_buckets) { // this can happen because of the lazy bucketing
+          return null_bkt;
+        }
+        return (bkt < (cur_range+1)*open_buckets) ? (bkt % open_buckets) : open_buckets;
+      } else {
+        if (bkt >= (cur_range)*open_buckets) {
+          return null_bkt;
+        }
+        return (bkt >= (cur_range-1)*open_buckets) ? ((open_buckets - (bkt % open_buckets)) - 1) : open_buckets;
+      }
+    }
+
+    size_t get_cur_bucket_num() const {
+      if (order == increasing) {
+        return cur_range*open_buckets + cur_bkt;
+      } else {
+        return (cur_range)*(open_buckets) - cur_bkt - 1;
+      }
+    }
+
+    inline bucket get_cur_bucket() {
+      id_dyn_arr bkt = bkts[cur_bkt];
+      size_t size = bkt.size;
+      num_elms -= size;
+      uintE* out = newA(uintE, size);
+      size_t cur_bkt_num = get_cur_bucket_num();
+      auto _d = d;
+      auto p = [&] (size_t i) { return _d(i) == cur_bkt_num; };
+      size_t m = pbbs::filterf(bkt.A, out, size, p);
+      bkts[cur_bkt].size = 0;
+      if (m == 0) {
+        free(out);
+        return next_bucket();
+      }
+      vertexSubset vs(n, m, out);
+      auto ret = bucket(cur_bkt_num, vs);
+      ret.num_filtered = size;
+      return ret;
+    }
+};
+
+template <class D>
+buckets<D> make_buckets(size_t n, D d, bucket_order order, size_t total_buckets=128) {
+  return buckets<D>(n, d, order, total_buckets);
+}

--- a/apps/bucketing/counting_sort.h
+++ b/apps/bucketing/counting_sort.h
@@ -1,0 +1,125 @@
+// This code is part of the Problem Based Benchmark Suite (PBBS)
+// Copyright (c) 2010-2016 Guy Blelloch and the PBBS team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights (to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+#include <stdio.h>
+#include "utils.h"
+#include "sequence.h"
+
+namespace pbbs {
+
+  // the following parameters can be tuned
+  constexpr const size_t _cs_seq_threshold = 2048;
+  constexpr const size_t _cs_max_blocks = 512;
+
+  // Sequential internal version
+  template <typename b_size_t, typename s_size_t, typename E, typename I, typename F>
+  inline void _seq_count_sort(I& In, E* Out, F& get_key,
+                       s_size_t start, s_size_t end,
+            		       s_size_t* counts, s_size_t num_buckets) {
+
+    s_size_t n = end-start;
+    s_size_t* offsets = new_array_no_init<s_size_t>(num_buckets);
+    b_size_t* tmp = new_array_no_init<b_size_t>(n);
+
+    for (s_size_t i = 0; i < num_buckets; i++) {
+      offsets[i] = 0;
+    }
+    for (s_size_t j = 0; j < n; j++) {
+      s_size_t k = tmp[j] = get_key(j + start);
+      offsets[k]++;
+    }
+    size_t s = 0;
+    for (s_size_t i = 0; i < num_buckets; i++) {
+      counts[i] = s;
+      s += offsets[i];
+      offsets[i] = s;
+    }
+    for (long j = ((long) n)-1; j >= 0; j--) {
+      s_size_t k =  --offsets[tmp[j]];
+      // needed for types with self defined assignment or initialization
+      // otherwise equivalent to: Out[k+start] = In[j+start];
+      move_uninitialized(Out[k+start], In[j+ start]);
+    }
+    free(offsets); free(tmp);
+  }
+
+  // Parallel internal version
+  template <typename b_size_t, typename s_size_t, typename E, typename I, typename F>
+  inline tuple<E*, s_size_t*, s_size_t> _count_sort(I& A, F& get_key, s_size_t n, s_size_t num_buckets) {
+    // pad to 16 buckets to avoid false sharing (does not affect results)
+
+    size_t sqrt = (size_t) ceil(pow(n,0.5));
+    size_t num_blocks = (size_t) (n < 20000000) ? (sqrt/10) : sqrt;
+    num_blocks = min(num_blocks, _cs_max_blocks);
+
+    //if (num_blocks < num_threads)
+    //  num_blocks = min((s_size_t) (n/(num_buckets*LOW_BUCKET_FACTOR*2) + 1),
+    //num_threads);
+    num_blocks = 1 << log2_up(num_blocks);
+
+    // if insufficient parallelism, sort sequentially
+    if (n < _cs_seq_threshold || num_blocks == 1) {
+      s_size_t* counts = new_array_no_init<s_size_t>(num_buckets+1);
+      E* B = new_array_no_init<E>(n);
+      _seq_count_sort<b_size_t>(A, B, get_key, (s_size_t)0, n, counts, num_buckets);
+      return make_tuple(B, counts, (s_size_t)1);
+    }
+
+    s_size_t block_size = ((n-1)/num_blocks) + 1;
+    s_size_t m = num_blocks * num_buckets;
+
+    E *B = new_array_no_init<E>(n); // warn: new_array will call cons on each item
+    s_size_t *counts = new_array_no_init<s_size_t>(m, 1);
+
+    // sort each block
+    parallel_for_1 (s_size_t i = 0; i < num_blocks; ++i) {
+      s_size_t start = std::min(i * block_size, n);
+      s_size_t end =  std::min(start + block_size, n);
+      _seq_count_sort<b_size_t>(A, B, get_key, start, end,
+				counts + i*num_buckets, num_buckets);
+    }
+
+    return make_tuple(B, counts, num_blocks);
+  }
+
+  template <typename s_size_t, typename E, typename F>
+    size_t* _count_sort_size(E* A, F& get_key, size_t n, size_t num_buckets) {
+    if (num_buckets <= 256) {
+      return _count_sort<uint8_t>(A, get_key, n, num_buckets);
+    } else if  (num_buckets < (1 << 16)) {
+      return _count_sort<uint16_t,s_size_t>(A, get_key, n, num_buckets);
+    } else {
+      return _count_sort<s_size_t,s_size_t>(A, get_key, n, num_buckets);
+    }
+  }
+
+  // Parallel version
+  template <typename E, typename F>
+  size_t* count_sort(E* A, F& get_key, size_t n, size_t num_buckets) {
+    size_t max32 = ((size_t) 1) << 32;
+    if (n < max32 && num_buckets < max32)
+      // use 4-byte counters when larger ones not needed
+      return _count_sort_size<uint32_t>(A, get_key, n, num_buckets);
+    return _count_sort_size<size_t>(A, get_key, n, num_buckets);
+  }
+}

--- a/apps/bucketing/dyn_arr.h
+++ b/apps/bucketing/dyn_arr.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "utils.h"
+
+#define MIN_BKT_SIZE 2048
+
+template <class E>
+struct dyn_arr {
+  E* A;
+  size_t size;
+  size_t capacity;
+  bool alloc;
+
+  dyn_arr() : A(NULL), size(0), capacity(0), alloc(false) {}
+  dyn_arr(size_t s) : size(0), capacity(s), alloc(true) { A = newA(E, s); }
+  dyn_arr(E* _A, long _size, long _capacity, bool _alloc) :
+    A(_A), size(_size), capacity(_capacity), alloc(_alloc) {}
+
+  void del() {
+    if (alloc) {
+      free(A);
+      alloc = false;
+    }
+  }
+
+  void clear() { size = 0; }
+
+  inline void resize(size_t n) {
+    if (n + size > capacity) {
+      size_t new_capacity = max(2*(n + size), (size_t)MIN_BKT_SIZE);
+      E* nA = newA(E, new_capacity);
+      granular_for(i, 0, size, 2000, nA[i] = A[i];);
+      if (alloc) {
+        free(A);
+      }
+      A = nA;
+      capacity = new_capacity;
+      alloc = true;
+    }
+  }
+
+  inline void insert(E val, size_t pos) {
+    A[size + pos] = val;
+  }
+
+  template <class F>
+  inline void copyIn(F f, size_t n) {
+    resize(n);
+    granular_for(i, 0, n, 2000, A[size + i] = f[i];);
+    size += n;
+  }
+
+  template <class F>
+  inline void copyInF(F f, size_t n) {
+    resize(n);
+    granular_for(i, 0, n, 2000, A[size + i] = f(i););
+    size += n;
+  }
+
+};
+
+

--- a/apps/bucketing/edgeMapReduce.h
+++ b/apps/bucketing/edgeMapReduce.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "ligra.h"
+#include "histogram.h"
+
+// edgeMapInduced
+// Version of edgeMapSparse that maps over the one-hop frontier and returns it as
+// a sparse array, without filtering.
+template <class E, class vertex, class VS, class F>
+inline vertexSubsetData<E> edgeMapInduced(graph<vertex>& GA, VS& V, F& f) {
+  vertex *G = GA.V;
+  uintT m = V.size();
+  V.toSparse();
+  auto degrees = array_imap<uintT>(m);
+  granular_for(i, 0, m, (m > 2000), {
+    vertex v = G[V.vtx(i)];
+    uintE degree = v.getOutDegree();
+    degrees[i] = degree;
+  });
+  long outEdgeCount = pbbs::scan_add(degrees, degrees);
+  if (outEdgeCount == 0) {
+    return vertexSubsetData<E>(GA.n);
+  }
+  typedef tuple<uintE, E> VE;
+  VE* outEdges = pbbs::new_array_no_init<VE>(outEdgeCount);
+
+  auto gen = [&] (const uintE& ngh, const uintE& offset, const Maybe<E>& val = Maybe<E>()) {
+    outEdges[offset] = make_tuple(ngh, val.t);
+  };
+
+  parallel_for (size_t i = 0; i < m; i++) {
+    uintT o = degrees[i];
+    auto v = V.vtx(i);
+    G[v].template copyOutNgh<E>(v, o, f, gen);
+  }
+  auto vs = vertexSubsetData<E>(GA.n, outEdgeCount, outEdges);
+  return vs;
+}
+
+template <class V, class vertex>
+struct EdgeMap {
+  using K = uintE; // keys are always uintE's (vertex-identifiers)
+  using KV = tuple<K, V>;
+  graph<vertex>& G;
+  pbbs::hist_table<K, V> ht;
+
+  EdgeMap(graph<vertex>& _G, KV _empty, size_t ht_size=numeric_limits<size_t>::max()) : G(_G) {
+    if (ht_size = numeric_limits<size_t>::max()) {
+      ht_size = G.m/20;
+    }
+    ht = pbbs::hist_table<K, V>(_empty, ht_size);
+  }
+
+  // map_f: (uintE v, uintE ngh) -> E
+  // reduce_f: (E, tuple(uintE ngh, E ngh_val)) -> E
+  // apply_f: (uintE ngh, E reduced_val) -> O
+  template <class O, class M, class Map, class Reduce, class Apply, class VS>
+  inline vertexSubsetData<O> edgeMapReduce(VS& vs, Map& map_f, Reduce& reduce_f, Apply& apply_f) {
+    size_t m = vs.size();
+    if (m == 0) {
+      return vertexSubsetData<O>(vs.numNonzeros());
+    }
+    vertex* frontierVertices = newA(vertex, m);
+    uintT* degrees = newA(uintT, m);
+    granular_for(i, 0, m, (m > 1000), {
+      frontierVertices[i] = G.V[vs.vtx(i)];
+      degrees[i] = frontierVertices[i].getOutDegree();
+    });
+
+    auto oneHop = edgeMapInduced<M, vertex, VS, Map>(G, vs, map_f);
+    oneHop.toSparse();
+
+    auto get_elm = make_in_imap<tuple<K, M> >(oneHop.size(), [&] (size_t i) { return oneHop.vtxAndData(i); });
+    auto get_key = make_in_imap<uintE>(oneHop.size(), [&] (size_t i) -> uintE { return oneHop.vtx(i); });
+
+    auto q = [&] (sequentialHT<K, V>& S, tuple<K, M> v) -> void { S.template insertF<M>(v, reduce_f); };
+    auto res = pbbs::histogram_reduce<tuple<K, M>, tuple<K, O> >(get_elm, get_key, oneHop.size(), q, apply_f, ht);
+    oneHop.del();
+    return vertexSubsetData<O>(vs.numNonzeros(), res.first, res.second);
+  }
+
+  template <class O, class Apply, class VS>
+  inline vertexSubsetData<O> edgeMapCount(VS& vs, Apply& apply_f) {
+    auto map_f = [] (const uintE& i, const uintE& j) { return pbbs::empty(); };
+    auto reduce_f = [&] (const uintE& cur, const tuple<uintE, pbbs::empty>& r) { return cur + 1; };
+    return edgeMapReduce<O, pbbs::empty>(vs, map_f, reduce_f, apply_f);
+  }
+
+  ~EdgeMap() {
+    ht.del();
+  }
+};

--- a/apps/bucketing/encoder.C
+++ b/apps/bucketing/encoder.C
@@ -1,0 +1,1 @@
+../../ligra/encoder.C

--- a/apps/bucketing/histogram.h
+++ b/apps/bucketing/histogram.h
@@ -1,0 +1,230 @@
+// This code is part of the Problem Based Benchmark Suite (PBBS)
+// Copyright (c) 2010-2016 Guy Blelloch and the PBBS team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights (to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+#include <math.h>
+#include <stdio.h>
+#include <cstdint>
+
+#include "counting_sort.h"
+#include "sequentialHT.h"
+#include "sequence.h"
+
+namespace pbbs {
+
+  // Tunable parameters
+  constexpr const size_t _hist_max_buckets = 2048;
+  constexpr const size_t _hist_seq_threshold = 3500;
+
+  template <class K, class V>
+  struct hist_table {
+    using KV = tuple<K, V>;
+    KV empty;
+    KV* table;
+    size_t size;
+    hist_table(KV _empty, size_t _size) : empty(_empty), size(_size) {
+      table = newA(KV, size);
+      parallel_for (size_t i=0; i<size; i++) { table[i] = empty; }
+    }
+    hist_table() {}
+
+    void resize(size_t req_size) {
+      if (req_size > size) {
+        free(table);
+        table = newA(KV, req_size);
+        size = req_size;
+        parallel_for (size_t i=0; i<size; i++) { table[i] = empty; }
+        cout << "resized to: " << size << endl;
+      }
+    }
+
+    void del() {
+      if (table) {
+        free(table);
+      }
+    }
+  };
+
+  template <class E, class O, class K, class V, class A, class Reduce, class Apply>
+  inline pair<size_t, O*> seq_histogram_reduce(A& get_elm, size_t n, Reduce& reduce_f, Apply& apply_f, hist_table<K, V>& ht) {
+    typedef tuple<K, V> KV;
+    ht.resize(n);
+    sequentialHT<K, V> S(ht.table, n, 1.0f, ht.empty);
+    for (size_t i=0; i<n; i++) {
+      E a = get_elm(i);
+      reduce_f(S, a);
+    }
+    O* out = newA(O, n);
+    size_t k = S.compactInto(apply_f, out);
+    return make_pair(k, out);
+  }
+
+  // Issue: want to make the type that's count-sort'd independent of K,V
+  // A : <E> elms
+  // B : inmap<keys> (numeric so that we can hash)
+  // E : type of intermediate elements (what we count sort)
+  // Q : reduction (seqHT<uintE, E>&, E&) -> void
+  // F : tuple<K, Elm> -> Maybe<uintE>
+  template <class E, class O, class K, class V, class A, class B, class Reduce, class Apply>
+  inline pair<size_t, O*> histogram_reduce(A& get_elm, B& get_key, size_t n, Reduce& reduce_f, Apply& apply_f, hist_table<K, V>& ht) {
+    typedef tuple<K, V> KV;
+
+    int nworkers = getWorkers();
+
+    if (n < _hist_seq_threshold || nworkers == 1) {
+      auto r = seq_histogram_reduce<E, O>(get_elm, n, reduce_f, apply_f, ht);
+      return r;
+    }
+
+    size_t sqrt = (size_t) ceil(pow(n,0.5));
+    size_t num_buckets = (size_t) (n < 20000000) ? (sqrt/10) : sqrt;
+    num_buckets = std::max(1 << log2_up(num_buckets), 1);
+    num_buckets = min(num_buckets, _hist_max_buckets);
+    size_t bits = log2_up(num_buckets);
+
+    // (1) count-sort based on bucket
+    // TODO: add back contention detection
+    size_t low_mask = ~((size_t)15);
+    size_t bucket_mask = num_buckets - 1;
+    auto get_bucket = [&] (uintE i) {
+      return pbbs::hash64(get_key[i] & low_mask) & bucket_mask;
+    };
+
+    auto p = _count_sort<int16_t, size_t, E>(get_elm, get_bucket, n, (uintE)num_buckets);
+
+    auto elms = std::get<0>(p); // count-sort'd
+    // laid out as num_buckets (row), blocks (col)
+    size_t* counts = std::get<1>(p);
+    size_t num_blocks = std::get<2>(p);
+    size_t block_size = ((n-1)/num_blocks) + 1;
+
+#define S_STRIDE 1
+    size_t* bkt_counts = new_array_no_init<size_t>(num_buckets*S_STRIDE);
+    parallel_for (size_t i=0; i<num_buckets; i++) {
+      bkt_counts[i*S_STRIDE] = 0;
+      if (i == (num_buckets-1)) {
+        for (size_t j=0; j<num_blocks; j++) {
+          size_t start = std::min(j * block_size, n);
+          size_t end =  std::min(start + block_size, n);
+          bkt_counts[i*S_STRIDE] += (end - start) - counts[j*num_buckets+i];
+        }
+      } else {
+        for (size_t j=0; j<num_blocks; j++) {
+          bkt_counts[i*S_STRIDE] += counts[j*num_buckets+i+1] - counts[j*num_buckets+i];
+        }
+      }
+    }
+
+    array_imap<size_t> out_offs = array_imap<size_t>(num_buckets+1);
+    array_imap<size_t> ht_offs = array_imap<size_t>(num_buckets+1);
+
+    // (2) process each bucket, compute the size of each HT and scan (seq)
+    ht_offs[0] = 0;
+    for (size_t i=0; i<num_buckets; i++) {
+      size_t size = bkt_counts[i*S_STRIDE];
+      size_t ht_size = 0;
+      if (size > 0) {
+        ht_size = 1 << pbbs::log2_up((intT)(size + 1));
+      }
+      ht_offs[i+1] = ht_offs[i] + ht_size;
+    }
+
+    ht.resize(ht_offs[num_buckets]);
+    O* out = newA(O, ht_offs[num_buckets]);
+
+    // (3) insert elms into per-bucket hash table (par)
+    parallel_for_1 (size_t i = 0; i < num_buckets; i++) {
+      size_t ht_start = ht_offs[i];
+      size_t ht_size = ht_offs[i+1] - ht_start;
+
+      size_t k = 0;
+      KV* table = ht.table;
+      if (ht_size > 0) {
+        KV* my_ht = &(table[ht_start]);
+        sequentialHT<K, V> S(my_ht, ht_size, ht.empty);
+
+        O* my_out = &(out[ht_start]);
+
+        for (size_t j=0; j<num_blocks; j++) {
+          size_t start = std::min(j * block_size, n);
+          size_t end =  std::min(start + block_size, n);
+          size_t ct = 0;
+          size_t off = 0;
+          if (i == (num_buckets-1)) {
+            off = counts[j*num_buckets+i];
+            ct = (end - start) - off;
+          } else {
+            off = counts[j*num_buckets+i];
+            ct = counts[j*num_buckets+i+1] - off;
+          }
+          off += start;
+          for (size_t k=0; k<ct; k++) {
+            E a = elms[off + k];
+            reduce_f(S, a);
+          }
+        }
+
+        k = S.compactInto(apply_f, my_out);
+      }
+      out_offs[i] = k;
+    }
+
+    // (4) scan
+    size_t ct = 0;
+    for (size_t i=0; i<num_buckets; i++) {
+      size_t s = ct;
+      ct += out_offs[i];
+      out_offs[i] = s;
+    }
+    out_offs[num_buckets] = ct;
+    uintT num_distinct = ct;
+
+    O* res = newA(O, ct);
+
+    // (5) map compacted hts to output, clear hts
+    parallel_for_1 (size_t i=0; i<num_buckets; i++) {
+      size_t o = out_offs[i];
+      size_t k = out_offs[(i+1)] - o;
+
+      size_t ht_start = ht_offs[i];
+      size_t ht_size = ht_offs[i+1] - ht_start;
+
+      if (ht_size > 0) {
+        O* my_out = &(out[ht_start]);
+
+        for (size_t j=0; j<k; j++) {
+          res[o+j] = my_out[j];
+        }
+      }
+    }
+
+    free(elms); free(counts); free(bkt_counts); free(out);
+    return make_pair(num_distinct, res);
+  }
+
+  template <class E, class A, class F, class Timer>
+  inline pair<size_t, tuple<E, E>*> histogram(A& get_elm, size_t n, F& f, hist_table<E, E>& ht, Timer& t) {
+    auto q = [] (sequentialHT<E, E>& S, E v) -> void { S.insertAdd(v); };
+    return histogram_reduce<E, tuple<E, E>>(get_elm, get_elm, n, q, f, ht, t);
+  }
+
+}

--- a/apps/bucketing/sequentialHT.h
+++ b/apps/bucketing/sequentialHT.h
@@ -1,0 +1,139 @@
+// This code is based on the paper "Phase-Concurrent Hash Tables for
+// Determinism" by Julian Shun and Guy Blelloch from SPAA 2014.
+// Copyright (c) 2014 Julian Shun and Guy Blelloch
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights (to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANBILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include "parallel.h"
+#include "utils.h"
+#include "maybe.h"
+using namespace std;
+
+template <class K, class V>
+class sequentialHT {
+ typedef tuple<K,V> T;
+
+ public:
+  size_t m;
+  intT mask;
+  T empty;
+  K max_key;
+  T* table;
+
+  inline size_t toRange(size_t h) {return h & mask;}
+  inline size_t firstIndex(K v) {return toRange(pbbs::hash64(v));}
+  inline size_t incrementIndex(size_t h) {return toRange(h+1);}
+
+  sequentialHT(T* _table, size_t size, float loadFactor, tuple<K, V> _empty) :
+    m((size_t) 1 << pbbs::log2_up((size_t)(loadFactor*size))),
+    mask(m-1), table(_table), empty(_empty) { max_key = get<0>(empty); }
+
+  // m must be a power of two
+  sequentialHT(T* _table, size_t _m, tuple<K, V> _empty) :
+    m((size_t)_m), mask(m-1), table(_table), empty(_empty) { max_key = get<0>(empty); }
+
+  template <class M, class F>
+  inline void insertF(tuple<K, M>& v, F& f) {
+    K vKey = get<0>(v);
+    size_t h = firstIndex(vKey);
+    while (1) {
+      auto k = get<0>(table[h]);
+      if (k == max_key) {
+        get<0>(table[h]) = vKey;
+        V cur = get<1>(table[h]);
+        get<1>(table[h]) = f(cur, v);
+        return;
+      } else if (k == vKey) {
+        V cur = get<1>(table[h]);
+        get<1>(table[h]) = f(cur, v);
+        return;
+      }
+      h = incrementIndex(h);
+    }
+  }
+
+  // V must support ++
+  inline void insertAdd(K& vKey) {
+    size_t h = firstIndex(vKey);
+    while (1) {
+      auto k = get<0>(table[h]);
+      if (k == max_key) {
+        table[h] = make_tuple(vKey, 1);
+        return;
+      } else if (k == vKey) {
+        get<1>(table[h])++;
+        return;
+      }
+      h = incrementIndex(h);
+    }
+  }
+
+  // V must support ++, T<1> must be numeric
+  inline void insertAdd(T& v) {
+    const K& vKey = get<0>(v);
+    size_t h = firstIndex(vKey);
+    while (1) {
+      auto k = get<0>(table[h]);
+      if (k == max_key) {
+        table[h] = make_tuple(vKey, 1);
+        return;
+      } else if (k == vKey) {
+        get<1>(table[h]) += get<1>(v);
+        return;
+      }
+      h = incrementIndex(h);
+    }
+  }
+
+  inline T find(K& v) {
+    size_t h = firstIndex(v);
+    T c = table[h];
+    while (1) {
+      if (get<0>(c) == max_key) {
+        return empty;
+      } else if (get<0>(c) == v) {
+      	return c;
+      }
+      h = incrementIndex(h);
+      c = table[h];
+    }
+  }
+
+  // F : KV -> E
+  template <class E, class F>
+  inline size_t compactInto(F& f, E* Out) {
+    size_t k = 0;
+    for (size_t i=0; i < m; i++) {
+      auto kv = table[i]; auto key = get<0>(kv);
+      if (key != max_key) {
+        table[i] = empty;
+        Maybe<E> value = f(kv);
+        if (isSome(value)) {
+          Out[k++] = getT(value);
+        }
+      }
+    }
+    return k;
+  }
+
+};
+

--- a/apps/eccentricity/Makefile
+++ b/apps/eccentricity/Makefile
@@ -9,7 +9,7 @@ endif
 #compilers
 ifdef CILK
 PCC = g++
-PCFLAGS = -fcilkplus -lcilkrts -O2 -DCILK $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -fcilkplus -lcilkrts -O2 -DCILK $(INTT) $(INTE)
 PLFLAGS = -fcilkplus -lcilkrts
 
 else ifdef MKLROOT
@@ -18,14 +18,14 @@ PCFLAGS = -O3 -DCILKP $(INTT) $(INTE)
 
 else ifdef OPENMP
 PCC = g++
-PCFLAGS = -fopenmp -O3 -DOPENMP $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -fopenmp -O3 -DOPENMP $(INTT) $(INTE)
 
 else
 PCC = g++
-PCFLAGS = -O2 $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -O2 $(INTT) $(INTE)
 endif
 
-COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h quickSort.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
+COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h index_map.h maybe.h sequence.h edgeMap_utils.h binary_search.h quickSort.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
 INTSORT= blockRadixSort.h transpose.h
 ALL= kBFS-1Phase-Ecc kBFS-Ecc FM-Ecc LogLog-Ecc kBFS-Exact RV CLRSTV TK Simple-Approx-Ecc
 

--- a/apps/localAlg/Makefile
+++ b/apps/localAlg/Makefile
@@ -9,23 +9,23 @@ endif
 #compilers
 ifdef CILK
 PCC = g++
-PCFLAGS = -fcilkplus -lcilkrts -std=c++11 -O2 -DCILK $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -fcilkplus -lcilkrts -O2 -DCILK $(INTT) $(INTE)
 PLFLAGS = -fcilkplus -lcilkrts
 
 else ifdef MKLROOT
 PCC = icpc
-PCFLAGS = -O3 -std=c++11 -DCILKP $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -O3 -DCILKP $(INTT) $(INTE)
 
 else ifdef OPENMP
 PCC = g++
-PCFLAGS = -fopenmp -O3 -std=c++11 -DOPENMP $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -fopenmp -O3 -DOPENMP $(INTT) $(INTE)
 
 else
 PCC = g++
-PCFLAGS = -std=c++11 -O2 $(INTT) $(INTE)
+PCFLAGS = -std=c++14 -O2 $(INTT) $(INTE)
 endif
 
-COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h quickSort.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
+COMMON= ligra.h graph.h compressedVertex.h vertex.h utils.h IO.h parallel.h gettime.h index_map.h maybe.h sequence.h edgeMap_utils.h binary_search.h quickSort.h parseCommandLine.h byte.h byteRLE.h nibble.h byte-pd.h byteRLE-pd.h nibble-pd.h vertexSubset.h encoder.C
 LOCAL_COMMON = sweep.h sparseSet.h sampleSort.h
 INTSORT= blockRadixSort.h transpose.h
 SERIAL = ACL-Serial ACL-Serial-Naive ACL-Serial-Opt ACL-Serial-Opt-Naive HeatKernel-Serial HeatKernel-Randomized-Serial Nibble-Serial

--- a/ligra/binary_search.h
+++ b/ligra/binary_search.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+
+namespace pbbs {
+  // the following parameter can be tuned
+  constexpr const size_t _binary_search_base = 16;
+
+  template <typename Sequence, typename F>
+  size_t linear_search(Sequence I, typename Sequence::T v, const F& less) {
+    for (size_t i = 0; i < I.size(); i++)
+      if (!less(I[i],v)) return i;
+    return I.size();
+  }
+
+  // return index to first key greater or equal to v
+  template <typename Sequence, typename F>
+  size_t binary_search(Sequence I, typename Sequence::T v, const F& less) {
+    size_t start = 0;
+    size_t end = I.size();
+    while (end-start > _binary_search_base) {
+      size_t mid = (end+start)/2;
+      if (!less(I[mid],v)) end = mid;
+      else start = mid + 1;
+    }
+    return start + linear_search(I.slice(start,end),v,less);
+  }
+}

--- a/ligra/byteRLE-pd.h
+++ b/ligra/byteRLE-pd.h
@@ -41,7 +41,7 @@
 typedef unsigned char uchar;
 
 /* Reads the first edge of an out-edge list, which is the signed
-   difference between the target and source. 
+   difference between the target and source.
 */
 
 inline intE eatWeight(uchar* &start) {
@@ -55,7 +55,7 @@ inline intE eatWeight(uchar* &start) {
       start++;
       if (LAST_BIT_SET(b))
         shiftAmount += EDGE_SIZE_PER_BYTE;
-      else 
+      else
         break;
     }
   }
@@ -75,7 +75,7 @@ inline intE eatFirstEdge(uchar* &start, uintE source) {
       start++;
       if (LAST_BIT_SET(b))
         shiftAmount += EDGE_SIZE_PER_BYTE;
-      else 
+      else
         break;
     }
   }
@@ -84,7 +84,7 @@ inline intE eatFirstEdge(uchar* &start, uintE source) {
 }
 
 /*
-  Reads any edge of an out-edge list after the first edge. 
+  Reads any edge of an out-edge list after the first edge.
 */
 inline uintE eatEdge(uchar* &start) {
   uintE edgeRead = 0;
@@ -95,19 +95,19 @@ inline uintE eatEdge(uchar* &start) {
     edgeRead += ((b & 0x7f) << shiftAmount);
     if (LAST_BIT_SET(b))
       shiftAmount += EDGE_SIZE_PER_BYTE;
-    else 
+    else
       break;
-  } 
+  }
   return edgeRead;
 }
 
 /*
-  The main decoding work-horse. First eats the specially coded first 
+  The main decoding work-horse. First eats the specially coded first
   edge, and then eats the remaining |d-1| many edges that are normally
-  coded. 
+  coded.
 */
-template <class T, class F>
-  inline void decode(T t, F &f, uchar* edgeStart, const uintE &source, const uintT &degree) {
+template <class T>
+  inline void decode(T t, uchar* edgeStart, const uintE &source, const uintT &degree, const bool par=true) {
   if (degree > 0) {
     uintE edgesRead = 0;
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
@@ -115,10 +115,10 @@ template <class T, class F>
     uchar* start = edgeStart + (numChunks-1)*sizeof(uintE);
     long end = min<long>(PARALLEL_DEGREE,degree);
     //do first chunk
-    // Eat first edge, which is compressed specially 
+    // Eat first edge, which is compressed specially
     uintE startEdge = eatFirstEdge(start,source);
     //cout << startEdge << endl;
-    if (!t.srcTarg(f, source,startEdge,edgesRead)) {
+    if (!t.srcTarg(source,startEdge,edgesRead)) {
       return;
     }
     uintT i = 0;
@@ -133,7 +133,7 @@ template <class T, class F>
 	for(uint j = 0; j < runlength; j++) {
 	  uintE edge = (uintE) start[i++] + startEdge;
 	  startEdge = edge;
-	  if (!t.srcTarg(f, source, edge, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -143,7 +143,7 @@ template <class T, class F>
 	  uintE edge = (uintE) start[i] + (((uintE) start[i+1]) << 8) + startEdge;
 	  i += 2;
 	  startEdge = edge;
-	  if (!t.srcTarg(f, source, edge, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -153,7 +153,7 @@ template <class T, class F>
 	  uintE edge = (uintE) start[i] + (((uintE) start[i+1]) << 8) + (((uintE) start[i+2]) << 16) + startEdge;
 	  i += 3;
 	  startEdge = edge;
-	  if (!t.srcTarg(f, source, edge, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -163,7 +163,7 @@ template <class T, class F>
 	  uintE edge = (uintE) start[i] + (((uintE) start[i+1]) << 8) + (((uintE) start[i+2]) << 16) + (((uintE) start[i+3]) << 24) + startEdge;
 	  i+=4;
 	  startEdge = edge;
-	  if (!t.srcTarg(f, source, edge, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -171,13 +171,13 @@ template <class T, class F>
     }
 
     //do remaining chunks in parallel
-    {parallel_for(long k=1;k<numChunks;k++) {
+    {granular_for(k, 1, numChunks, par, {
       long o = k*PARALLEL_DEGREE;
       long end = o+min<long>(PARALLEL_DEGREE,degree-o);
 
       uchar* myStart = edgeStart + pOffsets[k-1];
       uintE startEdge = eatFirstEdge(myStart,source);
-      if (!t.srcTarg(f, source,startEdge,o)) {
+      if (!t.srcTarg(source,startEdge,o)) {
 	end = 0;
       }
       uintT i = 0;
@@ -192,7 +192,7 @@ template <class T, class F>
 	  for(uint j = 0; j < runlength; j++) {
 	    uintE edge = (uintE) myStart[i++] + startEdge;
 	    startEdge = edge;
-	    if (!t.srcTarg(f, source, edge, edgeID++)) {
+	    if (!t.srcTarg(source, edge, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -202,7 +202,7 @@ template <class T, class F>
 	    uintE edge = (uintE) myStart[i] + (((uintE) myStart[i+1]) << 8) + startEdge;
 	    i += 2;
 	    startEdge = edge;
-	    if (!t.srcTarg(f, source, edge, edgeID++)) {
+	    if (!t.srcTarg(source, edge, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -212,7 +212,7 @@ template <class T, class F>
 	    uintE edge = (uintE) myStart[i] + (((uintE) myStart[i+1]) << 8) + (((uintE) myStart[i+2]) << 16) + startEdge;
 	    i += 3;
 	    startEdge = edge;
-	    if (!t.srcTarg(f, source, edge, edgeID++)) {
+	    if (!t.srcTarg(source, edge, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -222,20 +222,20 @@ template <class T, class F>
 	    uintE edge = (uintE) myStart[i] + (((uintE) myStart[i+1]) << 8) + (((uintE) myStart[i+2]) << 16) + (((uintE) myStart[i+3]) << 24) + startEdge;
 	    i+=4;
 	    startEdge = edge;
-	    if (!t.srcTarg(f, source, edge, edgeID++)) {
+	    if (!t.srcTarg(source, edge, edgeID++)) {
 	      end = 0;
 	    }
 	  }
 	}
       }
-      }    
+      });
     }
   }
 }
 
 
 /*
-  Compresses the first edge, writing target-source and a sign bit. 
+  Compresses the first edge, writing target-source and a sign bit.
 */
 long compressFirstEdge(uchar *start, long offset, uintE source, uintE target) {
   uchar* saveStart = start;
@@ -264,7 +264,7 @@ long compressFirstEdge(uchar *start, long offset, uintE source, uintE target) {
     // Check to see if there's any bits left to represent
     curByte = toCompress & 0x7f;
     if (toCompress > 0) {
-      toWrite |= 0x80; 
+      toWrite |= 0x80;
     }
     start[offset] = toWrite;
     offset++;
@@ -279,7 +279,7 @@ long compressFirstEdge(uchar *start, long offset, uintE source, uintE target) {
 long compressEdges(uchar *start, long curOffset, uintE* savedEdges, uintE edgeI, int numBytes, uintT runlength) {
   //header
   uchar header = numBytes - 1;
-  header |= ((runlength-1) << 2); 
+  header |= ((runlength-1) << 2);
   start[curOffset++] = header;
 
   for(int i=0;i<runlength;i++) {
@@ -305,7 +305,7 @@ long compressEdges(uchar *start, long curOffset, uintE* savedEdges, uintE edgeI,
 #define THREE_BYTES_SIGNED_MAX 8388608
 #define THREE_BYTES_SIGNED_MIN -8388607
 /*
-  Takes: 
+  Takes:
     1. The edge array of chars to write into
     2. The current offset into this array
     3. The vertices degree
@@ -320,25 +320,25 @@ long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degre
     long numChunks = 1 + (degree-1)/PARALLEL_DEGREE;
     uintE* pOffsets = (uintE*) edgeArray;
     currentOffset += (numChunks-1)*sizeof(uintE);
-    
+
     for(long i=0;i<numChunks;i++) {
       long o = i*PARALLEL_DEGREE;
-      long numEdges = min<long>(PARALLEL_DEGREE,degree-o); 
+      long numEdges = min<long>(PARALLEL_DEGREE,degree-o);
       uintE* myEdges = savedEdges + o;
       if(i > 0) pOffsets[i-1] = currentOffset-startOffset;
       // Compress the first edge whole, which is signed difference coded
 
-      currentOffset = compressFirstEdge(edgeArray, currentOffset, 
+      currentOffset = compressFirstEdge(edgeArray, currentOffset,
 					vertexNum, myEdges[0]);
-      
+
       if (numEdges == 1) continue; //return currentOffset;
       uintE edgeI = 1;
       uintT runlength = 0;
       int numBytes = 0;
       while(1) {
-	uintE difference = myEdges[edgeI+runlength] - 
+	uintE difference = myEdges[edgeI+runlength] -
 	  myEdges[edgeI+runlength - 1];
-	if(difference < ONE_BYTE) { 
+	if(difference < ONE_BYTE) {
 	  if(!numBytes) {numBytes = 1; runlength++;}
 	  else if(numBytes == 1) runlength++;
 	  else {
@@ -347,7 +347,7 @@ long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degre
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
 	  }
-	  
+
 	} else if(difference < TWO_BYTES) {
 	  if(!numBytes) {numBytes = 2; runlength++;}
 	  else if(numBytes == 2) runlength++;
@@ -385,14 +385,14 @@ long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degre
 	  currentOffset = compressEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, runlength);
 	  break;
 	}
-      }      
+      }
     }
   }
   return currentOffset;
 }
 
 /*
-  Compresses the edge set in parallel. 
+  Compresses the edge set in parallel.
 */
 uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE* Degrees) {
   cout << "parallel compressing, (n,m) = (" << n << "," << m << ")" << endl;
@@ -400,7 +400,7 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
   uintT *degrees = newA(uintT, n+1);
   long *charsUsedArr = newA(long, n);
   long *compressionStarts = newA(long, n+1);
-  {parallel_for(long i=0; i<n; i++) { 
+  {parallel_for(long i=0; i<n; i++) {
       degrees[i] = Degrees[i];
       charsUsedArr[i] = 2*(ceil((degrees[i] * 9) / 8) + 4);
   }}
@@ -411,22 +411,22 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
 
   {parallel_for(long i=0; i<n; i++) {
       edgePts[i] = iEdges+charsUsedArr[i];
-      long charsUsed = 
-	sequentialCompressEdgeSet((uchar *)(iEdges+charsUsedArr[i]), 
+      long charsUsed =
+	sequentialCompressEdgeSet((uchar *)(iEdges+charsUsedArr[i]),
 				  0, degrees[i+1]-degrees[i],
 				  i, edges + offsets[i]);
       charsUsedArr[i] = charsUsed;
   }}
 
-  // produce the total space needed for all compressed lists in chars. 
+  // produce the total space needed for all compressed lists in chars.
   long totalSpace = sequence::plusScan(charsUsedArr, compressionStarts, n);
   compressionStarts[n] = totalSpace;
   free(degrees);
   free(charsUsedArr);
-  
+
   uchar *finalArr = newA(uchar, totalSpace);
   cout << "total space requested is : " << totalSpace << endl;
-  float avgBitsPerEdge = (float)totalSpace*8 / (float)m; 
+  float avgBitsPerEdge = (float)totalSpace*8 / (float)m;
   cout << "Average bits per edge: " << avgBitsPerEdge << endl;
 
   {parallel_for(long i=0; i<n; i++) {
@@ -446,7 +446,7 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
 typedef pair<uintE,intE> intEPair;
 
 /*
-  Takes: 
+  Takes:
     1. The edge array of chars to write into
     2. The current offset into this array
     3. The vertices degree
@@ -457,7 +457,7 @@ typedef pair<uintE,intE> intEPair;
 */
 
 /*
-  Compresses the first edge, writing target-source and a sign bit. 
+  Compresses the first edge, writing target-source and a sign bit.
 */
 
 int numBytesSigned (intE x) {
@@ -465,8 +465,8 @@ int numBytesSigned (intE x) {
   else return 4;
 }
 
-template <class T, class F>
-  inline void decodeWgh(T t, F &f, uchar* edgeStart, const uintE &source, const uintT &degree) {
+template <class T>
+  inline void decodeWgh(T t, uchar* edgeStart, const uintE &source, const uintT &degree, const bool par=true) {
   if (degree > 0) {
     uintE edgesRead = 0;
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
@@ -474,10 +474,10 @@ template <class T, class F>
     uchar* start = edgeStart+(numChunks-1)*sizeof(uintE);
     long end = min<long>(PARALLEL_DEGREE,degree);
 
-    // Eat first edge, which is compressed specially 
+    // Eat first edge, which is compressed specially
     uintE startEdge = eatFirstEdge(start,source);
     intE weight = eatWeight(start);
-    if (!t.srcTarg(f, source,startEdge, weight, edgesRead)) {
+    if (!t.srcTarg(source,startEdge, weight, edgesRead)) {
       return;
     }
     uintT i = 0;
@@ -493,9 +493,9 @@ template <class T, class F>
 	  uintE edge = (uintE) start[i] + startEdge;
 	  startEdge = edge;
 	  uintE w = start[i+1]; //highest bit is sign bit
-	  intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);	  
+	  intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	  i+=2;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -507,7 +507,7 @@ template <class T, class F>
 	  uintE w = start[i+2]; //highest bit is sign bit
 	  intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	  i += 3;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -519,7 +519,7 @@ template <class T, class F>
 	  uintE w = start[i+3]; //highest bit is sign bit
 	  intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	  i+=4;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -531,7 +531,7 @@ template <class T, class F>
 	  uintE w = start[i+4]; //highest bit is sign bit
 	  intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	  i+=5;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -544,7 +544,7 @@ template <class T, class F>
 	  intE weight = (w & 0x7f) + (((uintE) start[i+2]) << 7) + (((uintE) start[i+3]) << 15)  + (((uintE) start[i+4]) << 23);
 	  if(w & 0x80) weight = -weight;
 	  i+=5;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -557,7 +557,7 @@ template <class T, class F>
 	  intE weight = (w & 0x7f) + (((uintE) start[i+3]) << 7) + (((uintE) start[i+4]) << 15)  + (((uintE) start[i+5]) << 23);
 	  if(w & 0x80) weight = -weight;
 	  i+=6;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -570,7 +570,7 @@ template <class T, class F>
 	  intE weight = (w & 0x7f) + (((uintE) start[i+4]) << 7) + (((uintE) start[i+5]) << 15)  + (((uintE) start[i+6]) << 23);
 	  if(w & 0x80) weight = -weight;
 	  i+=7;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
@@ -582,20 +582,20 @@ template <class T, class F>
 	  intE weight = (w & 0x7f) + (((uintE) start[i+5]) << 7) + (((uintE) start[i+6]) << 15)  + (((uintE) start[i+7]) << 23);
 	  if(w & 0x80) weight = -weight;
 	  i+=8;
-	  if (!t.srcTarg(f, source, edge, weight, edgesRead++)) {
+	  if (!t.srcTarg(source, edge, weight, edgesRead++)) {
 	    return;
 	  }
 	}
       }
     }
 
-    {parallel_for(long k=1;k<numChunks;k++) {
+    {granular_for(k, 1, numChunks, par, {
       long o = k*PARALLEL_DEGREE;
       long end = o+min<long>(PARALLEL_DEGREE,degree-o);
       uchar* myStart = edgeStart + pOffsets[k-1];
-      uintE startEdge = eatFirstEdge(myStart,source);    
+      uintE startEdge = eatFirstEdge(myStart,source);
       intE weight = eatWeight(myStart);
-      if (!t.srcTarg(f, source,startEdge, weight, o)) {
+      if (!t.srcTarg(source,startEdge, weight, o)) {
 	end = 0;
       }
 
@@ -612,9 +612,9 @@ template <class T, class F>
 	    uintE edge = (uintE) myStart[i] + startEdge;
 	    startEdge = edge;
 	    uintE w = myStart[i+1]; //highest bit is sign bit
-	    intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);	  
+	    intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	    i+=2;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -626,7 +626,7 @@ template <class T, class F>
 	    uintE w = myStart[i+2]; //highest bit is sign bit
 	    intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	    i += 3;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -638,7 +638,7 @@ template <class T, class F>
 	    uintE w = myStart[i+3]; //highest bit is sign bit
 	    intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	    i+=4;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -650,7 +650,7 @@ template <class T, class F>
 	    uintE w = myStart[i+4]; //highest bit is sign bit
 	    intE weight = (w & 0x80) ? -(w & 0x7f) : (w & 0x7f);
 	    i+=5;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -663,7 +663,7 @@ template <class T, class F>
 	    intE weight = (w & 0x7f) + (((uintE) myStart[i+2]) << 7) + (((uintE) myStart[i+3]) << 15)  + (((uintE) myStart[i+4]) << 23);
 	    if(w & 0x80) weight = -weight;
 	    i+=5;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -676,7 +676,7 @@ template <class T, class F>
 	    intE weight = (w & 0x7f) + (((uintE) myStart[i+3]) << 7) + (((uintE) myStart[i+4]) << 15)  + (((uintE) myStart[i+5]) << 23);
 	    if(w & 0x80) weight = -weight;
 	    i+=6;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -689,7 +689,7 @@ template <class T, class F>
 	    intE weight = (w & 0x7f) + (((uintE) myStart[i+4]) << 7) + (((uintE) myStart[i+5]) << 15)  + (((uintE) myStart[i+6]) << 23);
 	    if(w & 0x80) weight = -weight;
 	    i+=7;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
@@ -701,13 +701,13 @@ template <class T, class F>
 	    intE weight = (w & 0x7f) + (((uintE) myStart[i+5]) << 7) + (((uintE) myStart[i+6]) << 15)  + (((uintE) myStart[i+7]) << 23);
 	    if(w & 0x80) weight = -weight;
 	    i+=8;
-	    if (!t.srcTarg(f, source, edge, weight, edgeID++)) {
+	    if (!t.srcTarg(source, edge, weight, edgeID++)) {
 	      end = 0;
 	    }
 	  }
 	}
       }
-      }
+      });
     }
   }
 }
@@ -715,7 +715,7 @@ template <class T, class F>
 long compressWeightedEdges(uchar *start, long curOffset, intEPair* savedEdges, uintE edgeI, int numBytes, int numBytesWeight, uintT runlength) {
   //header
   uchar header = numBytes - 1;
-  if(numBytesWeight == 4) header |= 4; //use 3 bits for info on bytes needed 
+  if(numBytesWeight == 4) header |= 4; //use 3 bits for info on bytes needed
   header |= ((runlength-1) << 3);  //use 5 bits for run length
   start[curOffset++] = header;
 
@@ -732,7 +732,7 @@ long compressWeightedEdges(uchar *start, long curOffset, intEPair* savedEdges, u
     uintE wMag = abs(w);
     uchar curByte = wMag & 0x7f;
     wMag = wMag >> 7;
-    if(w < 0) start[curOffset++] = curByte | 0x80; 
+    if(w < 0) start[curOffset++] = curByte | 0x80;
     else start[curOffset++] = curByte;
     bytesUsed++;
     for(int j=1; j<numBytesWeight; j++) {
@@ -756,10 +756,10 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
       long numEdges = min<long>(PARALLEL_DEGREE,degree-o);
       intEPair* myEdges = savedEdges + o;
       if(i > 0) pOffsets[i-1] = currentOffset-startOffset;
-      currentOffset = compressFirstEdge(edgeArray, currentOffset, 
+      currentOffset = compressFirstEdge(edgeArray, currentOffset,
 					vertexNum, myEdges[0].first);
 
-      currentOffset = compressFirstEdge(edgeArray, currentOffset, 
+      currentOffset = compressFirstEdge(edgeArray, currentOffset,
 					0, myEdges[0].second);
 
       if (numEdges == 1) continue;
@@ -767,10 +767,10 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
       uintT runlength = 0;
       int numBytes = 0, numBytesWeight = 0;
       while(1) {
-	uintE difference = myEdges[edgeI+runlength].first - 
+	uintE difference = myEdges[edgeI+runlength].first -
 	  myEdges[edgeI+runlength - 1].first;
 	intE weight = myEdges[edgeI+runlength].second;
-	if(difference < ONE_BYTE && numBytesSigned(weight) == 1) { 
+	if(difference < ONE_BYTE && numBytesSigned(weight) == 1) {
 	  if(!numBytes) {numBytes = 1; numBytesWeight = 1; runlength++;}
 	  else if(numBytes == 1 && numBytesWeight == 1) runlength++;
 	  else {
@@ -778,9 +778,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(difference < ONE_BYTE && numBytesSigned(weight) == 4) { 
+	  }
+	}
+	else if(difference < ONE_BYTE && numBytesSigned(weight) == 4) {
 	  if(!numBytes) {numBytes = 1; numBytesWeight = 4; runlength++;}
 	  else if(numBytes == 1 && numBytesWeight == 4) runlength++;
 	  else {
@@ -788,9 +788,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(difference < TWO_BYTES && numBytesSigned(weight) == 1) { 
+	  }
+	}
+	else if(difference < TWO_BYTES && numBytesSigned(weight) == 1) {
 	  if(!numBytes) {numBytes = 2; numBytesWeight = 1; runlength++;}
 	  else if(numBytes == 2 && numBytesWeight == 1) runlength++;
 	  else {
@@ -798,9 +798,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(difference < TWO_BYTES && numBytesSigned(weight) == 4) { 
+	  }
+	}
+	else if(difference < TWO_BYTES && numBytesSigned(weight) == 4) {
 	  if(!numBytes) {numBytes = 2; numBytesWeight = 4; runlength++;}
 	  else if(numBytes == 2 && numBytesWeight == 4) runlength++;
 	  else {
@@ -808,9 +808,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(difference < THREE_BYTES && numBytesSigned(weight) == 1) { 
+	  }
+	}
+	else if(difference < THREE_BYTES && numBytesSigned(weight) == 1) {
 	  if(!numBytes) {numBytes = 3; numBytesWeight = 1; runlength++;}
 	  else if(numBytes == 3 && numBytesWeight == 1) runlength++;
 	  else {
@@ -818,9 +818,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(difference < THREE_BYTES && numBytesSigned(weight) == 4) { 
+	  }
+	}
+	else if(difference < THREE_BYTES && numBytesSigned(weight) == 4) {
 	  if(!numBytes) {numBytes = 3; numBytesWeight = 4; runlength++;}
 	  else if(numBytes == 3 && numBytesWeight == 4) runlength++;
 	  else {
@@ -828,9 +828,9 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
-	else if(numBytesSigned(weight) == 1) { 
+	  }
+	}
+	else if(numBytesSigned(weight) == 1) {
 	  if(!numBytes) {numBytes = 4; numBytesWeight = 1; runlength++;}
 	  else if(numBytes == 4 && numBytesWeight == 1) runlength++;
 	  else {
@@ -838,8 +838,8 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	    edgeI += runlength;
 	    runlength = numBytes = 0;
-	  }	  
-	} 
+	  }
+	}
 	else {
 	  if(!numBytes) {numBytes = 4; numBytesWeight = 4; runlength++;}
 	  else if(numBytes == 4 && numBytesWeight == 4) runlength++;
@@ -850,7 +850,7 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	    runlength = numBytes = 0;
 	  }
 	}
-	
+
 	if(runlength == 32) {
 	  currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	  edgeI += runlength;
@@ -861,7 +861,7 @@ long sequentialCompressWeightedEdgeSet(uchar *edgeArray, long currentOffset, uin
 	  currentOffset = compressWeightedEdges(edgeArray, currentOffset, myEdges, edgeI, numBytes, numBytesWeight, runlength);
 	  break;
 	}
-      }      
+      }
     }
   }
   return currentOffset;

--- a/ligra/edgeMap_utils.h
+++ b/ligra/edgeMap_utils.h
@@ -1,0 +1,181 @@
+// Contains helper functions and special cases of edgeMap. Most of these
+// functions are specialized for the type of data written per vertex using tools
+// from type_traits.
+
+#pragma once
+
+#include <type_traits>
+
+#include "binary_search.h"
+
+// For template meta-programming
+enum class enabler_t {};
+
+template<typename T>
+using EnableIf = typename std::enable_if<T::value, enabler_t>::type;
+
+template<typename T>
+using DisableIf = typename std::enable_if<!T::value, enabler_t>::type;
+
+template <typename data>
+using EnableIfEmpty = EnableIf<std::is_same<data, pbbs::empty>>;
+
+template <typename data>
+using DisableIfEmpty = DisableIf<std::is_same<data, pbbs::empty>>;
+
+// Standard version of edgeMapDense.
+template <class data, EnableIfEmpty<data>...>
+auto get_emdense_gen(tuple<bool, data>* next) {
+  return [&] (uintE ngh, bool m=false) {
+    if (m) next[ngh] = make_tuple(1, pbbs::empty()); };
+}
+
+template <class data, DisableIfEmpty<data>...>
+auto get_emdense_gen(tuple<bool, data>* next) {
+  return [&] (uintE ngh, Maybe<data> m=Maybe<data>()) {
+    if (m.exists) next[ngh] = make_tuple(1, m.t); };
+}
+
+// Standard version of edgeMapDenseForward.
+template <class data, EnableIfEmpty<data>...>
+auto get_emdense_forward_gen(tuple<bool, data>* next) {
+  return [&] (uintE ngh, bool m=false) {
+    if (m) next[ngh] = make_tuple(1, pbbs::empty()); };
+}
+
+template <class data, DisableIfEmpty<data>...>
+auto get_emdense_forward_gen(tuple<bool, data>* next) {
+  return [&] (uintE ngh, Maybe<data> m=Maybe<data>()) {
+    if (m.exists) next[ngh] = make_tuple(1, m.t); };
+}
+
+// Standard version of edgeMapSparse.
+template <class data, EnableIfEmpty<data>...>
+auto get_emsparse_gen(tuple<uintE, data>* outEdges) {
+  return [&] (uintE ngh, uintE offset, bool m=false) {
+    if (m) {
+      outEdges[offset] = make_tuple(ngh, pbbs::empty());
+    } else {
+      outEdges[offset] = make_tuple(UINT_E_MAX, pbbs::empty());
+    }
+  };
+}
+
+template <class data, DisableIfEmpty<data>...>
+auto get_emsparse_gen(tuple<uintE, data>* outEdges) {
+  return [&] (uintE ngh, uintE offset, Maybe<data> m=Maybe<data>()) {
+    if (m.exists) {
+      outEdges[offset] = make_tuple(ngh, m.t);
+    } else {
+      std::get<0>(outEdges[offset]) = UINT_E_MAX;
+    }
+  };
+}
+
+// An edgeMapSparse that just maps over the out-edges.
+template <class data, EnableIfEmpty<data>...>
+auto get_emsparse_nooutput_gen() {
+  return [&] (uintE ngh, uintE offset, bool m=false) { };
+}
+
+template <class data, DisableIfEmpty<data>...>
+auto get_emsparse_nooutput_gen() {
+  return [&] (uintE ngh, uintE offset, Maybe<data> m=Maybe<data>()) { };
+}
+
+// enabled only when <data != pbbs:empty>
+template <class data, class vertex, class vs, class F>
+void edgeMapSparseNoOutput(vertex* frontierVertices, vs &indices, uintT m, F &f) {
+  auto g = get_emsparse_nooutput_gen<data>();
+  parallel_for (size_t i = 0; i < m; i++) {
+    uintT v = indices.vtx(i), o = 0;
+    vertex vert = frontierVertices[i];
+    vert.decodeOutNghSparse(v, o, f, g);
+  }
+}
+
+// edgeMapSparse_no_filter
+// Version of edgeMapSparse that binary-searches and packs out blocks of the
+// next frontier.
+template <class data, EnableIfEmpty<data>...>
+auto get_emsparse_no_filter_gen(tuple<uintE, data>* outEdges) {
+  return [&] (uintE ngh, uintE offset, bool m=false) {
+    if (m) {
+      outEdges[offset] = make_tuple(ngh, pbbs::empty());
+      return true;
+    }
+    return false;
+  };
+}
+
+template <class data, DisableIfEmpty<data>...>
+auto get_emsparse_no_filter_gen(tuple<uintE, data>* outEdges) {
+  return [&] (uintE ngh, uintE offset, Maybe<data> m=Maybe<data>()) {
+    if (m.exists) {
+      outEdges[offset] = make_tuple(ngh, m.t);
+      return true;
+    }
+    return false;
+  };
+}
+
+template <class data, class vertex, class vs, class F>
+pair<size_t, tuple<uintE, data>*> edgeMapSparse_no_filter(vertex* frontierVertices, vs& indices,
+      uintT* offsets, uintT m, F& f) {
+  using S = tuple<uintE, data>;
+  long outEdgeCount = sequence::plusScan(offsets, offsets, m);
+  S* outEdges = newA(S, outEdgeCount);
+
+  auto g = get_emsparse_no_filter_gen<data>(outEdges);
+
+  // binary-search into scan to map workers->chunks
+  size_t b_size = 10000;
+  size_t n_blocks = nblocks(outEdgeCount, b_size);
+
+  uintE* cts = newA(uintE, n_blocks+1);
+  size_t* block_offs = newA(size_t, n_blocks+1);
+
+  auto offsets_m = make_in_imap<uintT>(m, [&] (size_t i) { return offsets[i]; });
+  auto lt = [] (const uintT& l, const uintT& r) { return l < r; };
+  parallel_for(size_t i=0; i<n_blocks; i++) {
+    size_t s_val = i*b_size;
+    block_offs[i] = pbbs::binary_search(offsets_m, s_val, lt);
+  }
+  block_offs[n_blocks] = m;
+  parallel_for (size_t i=0; i<n_blocks; i++) {
+    if ((i == n_blocks-1) || block_offs[i] != block_offs[i+1]) {
+      // start and end are offsets in [m]
+      size_t start = block_offs[i];
+      size_t end = block_offs[i+1];
+      uintT start_o = offsets[start];
+      uintT k = start_o;
+      for (size_t j=start; j<end; j++) {
+        uintE v = indices.vtx(j);
+        size_t num_in = frontierVertices[j].decodeOutNghSparseSeq(v, k, f, g);
+        k += num_in;
+      }
+      cts[i] = (k - start_o);
+    } else {
+      cts[i] = 0;
+    }
+  }
+
+  long outSize = sequence::plusScan(cts, cts, n_blocks);
+  cts[n_blocks] = outSize;
+
+  S* out = newA(S, outSize);
+
+  parallel_for (size_t i=0; i<n_blocks; i++) {
+    if ((i == n_blocks-1) || block_offs[i] != block_offs[i+1]) {
+      size_t start = block_offs[i];
+      size_t start_o = offsets[start];
+      size_t out_off = cts[i];
+      size_t block_size = cts[i+1] - out_off;
+      for (size_t j=0; j<block_size; j++) {
+        out[out_off + j] = outEdges[start_o + j];
+      }
+    }
+  }
+  free(outEdges); free(cts); free(block_offs);
+  return make_pair(outSize, out);
+}

--- a/ligra/index_map.h
+++ b/ligra/index_map.h
@@ -1,0 +1,130 @@
+// An implementation of index_maps written by Guy Blelloch for pbbs.
+//
+// An index map is an alternative to iterators that can be better
+// in certain applications, especially parallel code.
+//
+// Index maps have an associated length n (A.size()),
+// and supply the functions:
+//     A[i] that  "reads" the i'th index, and
+//     A.update(i,v) that updates the i'th index with v.
+// Both are only valid for i = [0,n).
+// Input index maps only supply the first, output index maps only the
+// second, and input/output index maps supply both.
+
+// Index maps are useful when not just reading or writing contiguously in
+// an arrary.    They can save time and memory by avoiding copying.
+// Some applications include
+//
+// accessing every k'th element of an array A:
+//     make_in_imap<T>(n, [&] (size_t i) {return A[i*k];})
+// accessing fields of a structure:
+//     make_in_imap<T>(n, [&] (size_t i) {return A[i].my_field;})
+// applying a function to each element of an array:
+//     make_in_imap<T>(n, [&] (size_t i) {return f(A[i]);})
+// defining elements to be some function of i, e.g. its square:
+//     make_in_imap<T>(n, [] (size_t i) {return i*i;})
+// an arbitrary function can be applied on writing:
+//     make_out_imap<T>(n, [&] (size_t i, T v) {A[i] = f(v);})
+// or every other element can be written:
+//     make_out_imap<T>(n, [&] (size_t i, T v) {A[i*n] = f(v);})
+//
+// Random access iterators can be converted into an index map:
+//     make_iter_map(start, end)
+// This creates an input/output map
+//
+// And the simplest usage is converting an array into an index map:
+//     make_array_map(A, n)
+// This also creates an input/output map
+
+#pragma once
+
+#include "utils.h"
+
+template <typename E, typename F>
+struct in_imap {
+  using T = E;
+  F f;
+  size_t s, e;
+  in_imap(size_t n, F f) : f(f), s(0), e(n) {};
+  in_imap(size_t s, size_t e, F f) : f(f), s(s), e(e) {};
+  inline T operator[] (const size_t i) {return f(i+s);}
+  inline T operator() (const size_t i) {return f(i+s);}
+  in_imap<T,F> cut(size_t ss, size_t ee) {return in_imap<T,F>(s+ss,s+ee,f); }
+  in_imap<T,F> slice(size_t ss, size_t ee) {return in_imap<T,F>(s+ss,s+ee,f); }
+  size_t size() { return e - s;}
+};
+
+// used so second template argument can be inferred
+template <class E, class F>
+in_imap<E,F> make_in_imap (size_t n, F f) {
+  return in_imap<E,F>(n,f);
+}
+
+template <typename E, typename F>
+struct out_imap {
+  using T = E;
+  F f;
+  size_t s, e;
+  out_imap(size_t n, F f) : f(f), s(0), e(n) {};
+  out_imap(size_t s, size_t e, F f) : f(f), s(s), e(e) {};
+  out_imap<T,F> cut(size_t ss, size_t ee) {return out_imap<T,F>(s+ss,s+ee,f); }
+  void update(size_t i, const T& val) {f(i+s, val);}
+  size_t size() { return e - s;}
+};
+
+// used so second template argument can be inferred
+template <class E, class F>
+out_imap<E,F> make_out_imap (size_t n, F f) {
+  return out_imap<E,F>(n,f);
+}
+
+template <typename Iterator>
+struct iter_imap {
+  using T = typename std::iterator_traits<Iterator>::value_type;
+  Iterator s;
+  const Iterator e;
+  iter_imap(const iter_imap& b) : s(b.s), e(b.e) {}
+  iter_imap() {}
+  iter_imap(Iterator s, Iterator e) : s(s), e(e) {};
+  T& operator[] (const size_t i) const {return s[i];}
+  iter_imap<Iterator> cut(size_t ss, size_t ee) {
+    return iter_imap<Iterator>(s + ss, s + ee);}
+  void update(size_t i, const T& val) {s[i] = val;}
+  const size_t size() { return e - s;}
+};
+
+// used so template argument can be inferred
+template <class Iterator>
+iter_imap<Iterator> make_iter_imap (Iterator s, Iterator e) {
+  return iter_imap<Iterator>(s,e);
+}
+
+template <typename E>
+struct array_imap {
+  using T = E;
+  E *s, *e;
+  bool alloc;
+  array_imap(const array_imap& b) : s(b.s), e(b.e), alloc(false) {}
+  array_imap() : alloc(false) {}
+  array_imap(E* s, size_t n, bool alloc=false)
+    : s(s), e(s + n), alloc(alloc) {};
+  array_imap(const size_t n) : s(pbbs::new_array_no_init<E>(n)), e(s + n), alloc(true) {};
+  template <class F>
+  array_imap(const size_t n, F f) : s(pbbs::new_array_no_init<E>(n)), e(s + n), alloc(true) {
+    granular_for(i, 0, n, (n > 2000), { s[i] = f(i); });
+  };
+  ~array_imap() { if (alloc) { free(s);}}
+  inline E& operator[] (const size_t i) const {return s[i];}
+  inline E& operator() (const size_t i) const {return s[i];}
+  inline array_imap<T> cut(size_t ss, size_t ee) {
+    return array_imap<T>(s + ss, ee - ss);}
+  inline void update(size_t i, const E& val) {s[i] = val;}
+//  inline void del() { if (alloc) { alloc = false; free(s); }}
+  inline const size_t size() { return e - s;}
+};
+
+// used so template argument can be inferred
+template <class E>
+array_imap<E> make_array_imap (E* A, size_t n) {
+  return array_imap<E>(A,n);
+}

--- a/ligra/ligra.h
+++ b/ligra/ligra.h
@@ -39,6 +39,8 @@
 #include "IO.h"
 #include "parseCommandLine.h"
 #include "gettime.h"
+#include "index_map.h"
+#include "edgeMap_utils.h"
 using namespace std;
 
 //*****START FRAMEWORK*****
@@ -46,114 +48,267 @@ using namespace std;
 //options to edgeMap for different versions of dense edgeMap (default is DENSE)
 enum options { DENSE, DENSE_FORWARD };
 
-template <class vertex, class F>
-bool* edgeMapDense(graph<vertex> GA, bool* vertexSubset, F &f, bool parallel = 0) {
+typedef uint32_t flags;
+const flags output = 1;
+const flags no_output = 2;
+const flags pack_edges = 4;
+const flags sparse_no_filter = 8;
+
+template <class data, class vertex, class VS, class F>
+tuple<bool, data>* edgeMapDense(graph<vertex> GA, VS& vertexSubset, F &f, bool parallel = 0) {
+  using D = tuple<bool, data>;
   long numVertices = GA.n;
   vertex *G = GA.V;
-  bool* next = newA(bool,numVertices);
-  {parallel_for (long i=0; i<numVertices; i++) {
-    next[i] = 0;
-    if (f.cond(i)) {
-      G[i].decodeInNghBreakEarly(i, vertexSubset, f, next, parallel);
+  D* next = newA(D, numVertices);
+  auto g = get_emdense_gen<data>(next);
+  parallel_for (long v=0; v<numVertices; v++) {
+    std::get<0>(next[v]) = 0;
+    if (f.cond(v)) {
+      G[v].decodeInNghBreakEarly(v, vertexSubset, f, g, parallel);
     }
-  }}
+  }
   return next;
 }
 
-template <class vertex, class F>
-bool* edgeMapDenseForward(graph<vertex> GA, bool* vertexSubset, F &f) {
-  long numVertices = GA.n;
+template <class data, class vertex, class VS, class F>
+tuple<bool, data>* edgeMapDenseForward(graph<vertex> GA, VS& vertexSubset, F &f) {
+  using D = tuple<bool, data>;
+  long n = GA.n;
   vertex *G = GA.V;
-  bool* next = newA(bool,numVertices);
-  {parallel_for(long i=0;i<numVertices;i++) next[i] = 0;}
-  {parallel_for (long i=0; i<numVertices; i++){
-    if (vertexSubset[i]) {
-      G[i].decodeOutNgh(i, vertexSubset, f, next);
+  D* next = newA(D, n);
+  auto g = get_emdense_forward_gen<data>(next);
+  parallel_for(long i=0;i<n;i++) { std::get<0>(next[i]) = 0; }
+  parallel_for (long i=0; i<n; i++) {
+    if (vertexSubset.isIn(i)) {
+      G[i].decodeOutNgh(i, f, g);
     }
-  }}
+  }
   return next;
 }
 
-template <class vertex, class F>
-pair<long,uintE*> edgeMapSparse(vertex* frontierVertices, uintE* indices, 
-        uintT* degrees, uintT m, F &f, 
-        long remDups=0, uintE* flags=NULL) {
+template <class data, class vertex, class vs, class F>
+pair<size_t, tuple<uintE, data>*> edgeMapSparse(vertex* frontierVertices, vs &indices,
+        uintT* degrees, uintT m, F &f) {
+  using S = tuple<uintE, data>;
   uintT* offsets = degrees;
-  long outEdgeCount = sequence::plusScan(offsets, degrees, m);
-  uintE* outEdges = newA(uintE,outEdgeCount);
-  {parallel_for (long i = 0; i < m; i++) {
-      uintT v = indices[i], o = offsets[i];
-      vertex vert = frontierVertices[i]; 
-      vert.decodeOutNghSparse(v, o, f, outEdges);
-    }}
-  uintE* nextIndices = newA(uintE, outEdgeCount);
-  if(remDups) remDuplicates(outEdges,flags,outEdgeCount,remDups);
-  // Filter out the empty slots (marked with -1)
-  long nextM = sequence::filter(outEdges,nextIndices,outEdgeCount,nonMaxF());
+  long outEdgeCount = sequence::plusScan(offsets, offsets, m);
+  S* outEdges = newA(S, outEdgeCount);
+
+  auto g = get_emsparse_gen<data>(outEdges);
+
+  parallel_for (size_t i = 0; i < m; i++) {
+    uintT v = indices.vtx(i), o = offsets[i];
+    vertex vert = frontierVertices[i];
+    vert.decodeOutNghSparse(v, o, f, g);
+  }
+  S* nextIndices = newA(S, outEdgeCount);
+
+  auto p = [] (tuple<uintE, data>& v) { return std::get<0>(v) != UINT_E_MAX; };
+  size_t nextM = pbbs::filterf(outEdges, nextIndices, outEdgeCount, p);
   free(outEdges);
-  return pair<long,uintE*>(nextM, nextIndices);
+  return make_pair(nextM, nextIndices);
 }
 
-// decides on sparse or dense base on number of nonzeros in the active vertices
-template <class vertex, class F>
-vertexSubset edgeMap(graph<vertex> GA, vertexSubset &V, F f, intT threshold = -1, 
-		 char option=DENSE, bool remDups=false) {
-  long numVertices = GA.n, numEdges = GA.m;
+// Decides on sparse or dense base on number of nonzeros in the active vertices.
+template <class data, class vertex, class VS, class F>
+vertexSubsetData<data> edgeMapData(const graph<vertex>& GA, VS &vs, F f,
+    intT threshold = -1, char option=DENSE, const flags& fl=output) {
+  long numVertices = GA.n, numEdges = GA.m, m = vs.numNonzeros();
   if(threshold == -1) threshold = numEdges/20; //default threshold
   vertex *G = GA.V;
-  long m = V.numNonzeros();
-  if (numVertices != V.numRows()) {
+  if (numVertices != vs.numRows()) {
     cout << "edgeMap: Sizes Don't match" << endl;
     abort();
   }
-  // used to generate nonzero indices to get degrees
+  if (vs.size() == 0) return vertexSubsetData<data>(numVertices);
+  vs.toSparse();
   uintT* degrees = newA(uintT, m);
-  vertex* frontierVertices;
-  V.toSparse();
-  frontierVertices = newA(vertex,m);
-  {parallel_for (long i=0; i < m; i++){
-    vertex v = G[V.s[i]];
+  vertex* frontierVertices = newA(vertex,m);
+  {parallel_for (size_t i=0; i < m; i++) {
+    uintE v_id = vs.vtx(i);
+    vertex v = G[v_id];
     degrees[i] = v.getOutDegree();
     frontierVertices[i] = v;
-    }}
+  }}
+
   uintT outDegrees = sequence::plusReduce(degrees, m);
-  if (outDegrees == 0) return vertexSubset(numVertices);
-  if (m + outDegrees > threshold) { 
-    V.toDense();
-    free(degrees);
-    free(frontierVertices);
-    bool* R = (option == DENSE_FORWARD) ? 
-      edgeMapDenseForward(GA,V.d,f) : 
-      edgeMapDense(GA, V.d, f, option);
-    vertexSubset v1 = vertexSubset(numVertices, R);
-    //cout << "size (D) = " << v1.m << endl;
+  if (outDegrees == 0) return vertexSubsetData<data>(numVertices);
+  if (m + outDegrees > threshold) {
+    vs.toDense();
+    free(degrees); free(frontierVertices);
+    tuple<bool, data>* R = (option == DENSE_FORWARD) ?
+      edgeMapDenseForward<data, vertex, VS, F>(GA, vs, f) :
+      edgeMapDense<data, vertex, VS, F>(GA, vs, f, option);
+    vertexSubsetData<data> v1 = vertexSubsetData<data>(numVertices, R);
     return v1;
-  } else { 
-    pair<long,uintE*> R = 
-      remDups ? 
-      edgeMapSparse(frontierVertices, V.s, degrees, V.numNonzeros(), f, 
-		    numVertices, GA.flags) :
-      edgeMapSparse(frontierVertices, V.s, degrees, V.numNonzeros(), f);
-    //cout << "size (S) = " << R.first << endl;
-    free(degrees);
-    free(frontierVertices);
-    return vertexSubset(numVertices, R.first, R.second);
+  } else {
+    pair<size_t, tuple<uintE, data>*> R =
+      (fl & sparse_no_filter) ?
+      edgeMapSparse_no_filter<data, vertex, VS, F>(frontierVertices, vs, degrees, vs.numNonzeros(), f) :
+      edgeMapSparse<data, vertex, VS, F>(frontierVertices, vs, degrees, vs.numNonzeros(), f);
+    free(degrees); free(frontierVertices);
+    return vertexSubsetData<data>(numVertices, R.first, R.second);
   }
 }
 
+// Version of edgeMap which produces no output.
+template <class outdata, class vertex, class VS, class F>
+vertexSubsetData<outdata> edgeMapNoOutput(graph<vertex> GA, VS &vs, F f,
+    intT threshold = -1, char option=DENSE, const flags& fl=output) {
+  long numVertices = GA.n, numEdges = GA.m, m = vs.numNonzeros();
+  if(threshold == -1) threshold = numEdges/20;
+  vertex *V = GA.V;
+  if (numVertices != vs.numRows()) {
+    cout << "edgeMap: Sizes Don't match" << endl;
+    abort();
+  }
+  if (vs.size() == 0) {
+    return vertexSubsetData<outdata>(numVertices);
+  }
+
+  vs.toSparse();
+  vertex* frontierVertices = newA(vertex,m);
+  {parallel_for (size_t i=0; i < m; i++) {
+    uintE v_id = vs.vtx(i);
+    vertex v = V[v_id];
+    frontierVertices[i] = v;
+  }}
+
+  edgeMapSparseNoOutput<outdata, vertex, VS, F>(frontierVertices, vs, vs.numNonzeros(), f);
+  free(frontierVertices);
+  return vertexSubsetData<outdata>(numVertices);
+}
+
+// Main edgeMap function, which determines which implementation to call based on
+// the flags provided by the user.
+template <class vertex, class VS, class F>
+vertexSubset edgeMap(graph<vertex> GA, VS& vs, F f,
+    intT threshold = -1, char option=DENSE, const flags& fl=output) {
+  if (fl & no_output) {
+    return edgeMapNoOutput<pbbs::empty>(GA, vs, f, threshold, option, fl);
+  } else {
+    return edgeMapData<pbbs::empty>(GA, vs, f, threshold, option, fl);
+  }
+}
+
+// Packs out the adjacency lists of all vertex in vs. A neighbor, ngh, is kept
+// in the new adjacency list if p(ngh) is true.
+// Weighted graphs are not yet supported, but this should be easy to do.
+template <class vertex, class P>
+vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output) {
+  using S = tuple<uintE, uintE>;
+  vs.toSparse();
+  vertex* G = GA.V; long m = vs.numNonzeros(); long n = vs.numRows();
+  if (vs.size() == 0) {
+    return vertexSubsetData<uintE>(n);
+  }
+  auto degrees = array_imap<uintT>(m);
+  granular_for(i, 0, m, (m > 2000), {
+    uintE v = vs.vtx(i);
+    degrees[i] = G[v].getOutDegree();
+  });
+  long outEdgeCount = pbbs::scan_add(degrees, degrees);
+  S* outV;
+  if (fl & output) {
+    outV = newA(S, vs.size());
+  }
+
+  bool* bits = newA(bool, outEdgeCount);
+  uintE* tmp1 = newA(uintE, outEdgeCount);
+  uintE* tmp2 = newA(uintE, outEdgeCount);
+  if (fl & output) {
+    parallel_for (size_t i=0; i<m; i++) {
+      uintE v = vs.vtx(i);
+      size_t offset = degrees[i];
+      auto bitsOff = &(bits[offset]); auto tmp1Off = &(tmp1[offset]);
+      auto tmp2Off = &(tmp2[offset]);
+      size_t ct = G[v].packOutNgh(v, p, bitsOff, tmp1Off, tmp2Off);
+      outV[i] = make_tuple(v, ct);
+    }
+  } else {
+    parallel_for (size_t i=0; i<m; i++) {
+      uintE v = vs.vtx(i);
+      size_t offset = degrees[i];
+      auto bitsOff = &(bits[offset]); auto tmp1Off = &(tmp1[offset]);
+      auto tmp2Off = &(tmp2[offset]);
+      size_t ct = G[v].packOutNgh(v, p, bitsOff, tmp1Off, tmp2Off);
+    }
+  }
+  free(bits); free(tmp1); free(tmp2);
+  if (fl & output) {
+    return vertexSubsetData<uintE>(n, m, outV);
+  } else {
+    return vertexSubsetData<uintE>(n);
+  }
+}
+
+template <class vertex, class P>
+vertexSubsetData<uintE> edgeMapFilter(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output) {
+  vs.toSparse();
+  if (fl & pack_edges) {
+    return packEdges<vertex, P>(GA, vs, p, fl);
+  }
+  vertex* G = GA.V; long m = vs.numNonzeros(); long n = vs.numRows();
+  using S = tuple<uintE, uintE>;
+  if (vs.size() == 0) {
+    return vertexSubsetData<uintE>(n);
+  }
+  S* outV;
+  if (fl & output) {
+    outV = newA(S, vs.size());
+  }
+  if (fl & output) {
+    parallel_for (size_t i=0; i<m; i++) {
+      uintE v = vs.vtx(i);
+      size_t ct = G[v].countOutNgh(v, p);
+      outV[i] = make_tuple(v, ct);
+    }
+  } else {
+    parallel_for (size_t i=0; i<m; i++) {
+      uintE v = vs.vtx(i);
+      size_t ct = G[v].countOutNgh(v, p);
+    }
+  }
+  if (fl & output) {
+    return vertexSubsetData<uintE>(n, m, outV);
+  } else {
+    return vertexSubsetData<uintE>(n);
+  }
+}
+
+
+
 //*****VERTEX FUNCTIONS*****
 
-//Note: this is the optimized version of vertexMap which does not
-//perform a filter
-template <class F>
-void vertexMap(vertexSubset V, F add) {
-  long n = V.numRows(), m = V.numNonzeros();
-  if(V.isDense) {
-    {parallel_for(long i=0;i<n;i++)
-	if(V.d[i]) add(i);}
+template <class VS, class F, DisableIf<std::is_same<VS, vertexSubset>>...>
+void vertexMap(VS& V, F f) {
+  size_t n = V.numRows(), m = V.numNonzeros();
+  if(V.dense()) {
+    parallel_for(long i=0;i<n;i++) {
+      if(V.isIn(i)) {
+        f(i, V.ithData(i));
+      }
+    }
   } else {
-    {parallel_for(long i=0;i<m;i++)
-	add(V.s[i]);}
+    parallel_for(long i=0;i<m;i++) {
+      f(V.vtx(i), V.vtxData(i));
+    }
+  }
+}
+
+template <class VS, class F, EnableIf<std::is_same<VS, vertexSubset>>...>
+void vertexMap(VS& V, F f) {
+  size_t n = V.numRows(), m = V.numNonzeros();
+  if(V.dense()) {
+    parallel_for(long i=0;i<n;i++) {
+      if(V.isIn(i)) {
+        f(i);
+      }
+    }
+  } else {
+    parallel_for(long i=0;i<m;i++) {
+      f(V.vtx(i));
+    }
   }
 }
 
@@ -170,6 +325,48 @@ vertexSubset vertexFilter(vertexSubset V, F filter) {
   return vertexSubset(n,d_out);
 }
 
+template <class F>
+vertexSubset vertexFilter2(vertexSubset V, F filter) {
+  long n = V.numRows(), m = V.numNonzeros();
+  if (m == 0) {
+    return vertexSubset(n);
+  }
+  bool* bits = newA(bool, m);
+  V.toSparse();
+  {parallel_for(size_t i=0; i<m; i++) {
+    uintE v = V.vtx(i);
+    bits[i] = filter(v);
+  }}
+  auto v_imap = make_in_imap<uintE>(m, [&] (size_t i) { return V.vtx(i); });
+  auto bits_m = make_in_imap<bool>(m, [&] (size_t i) { return bits[i]; });
+  auto out = pbbs::pack(v_imap, bits_m);
+  out.alloc = false;
+  free(bits);
+  return vertexSubset(n, out.size(), out.s);
+}
+
+template <class data, class F>
+vertexSubset vertexFilter2(vertexSubsetData<data> V, F filter) {
+  long n = V.numRows(), m = V.numNonzeros();
+  if (m == 0) {
+    return vertexSubset(n);
+  }
+  bool* bits = newA(bool, m);
+  V.toSparse();
+  parallel_for(size_t i=0; i<m; i++) {
+    auto t = V.vtxAndData(i);
+    bits[i] = filter(std::get<0>(t), std::get<1>(t));
+  }
+  auto v_imap = make_in_imap<uintE>(m, [&] (size_t i) { return V.vtx(i); });
+  auto bits_m = make_in_imap<bool>(m, [&] (size_t i) { return bits[i]; });
+  auto out = pbbs::pack(v_imap, bits_m);
+  out.alloc = false;
+  free(bits);
+  return vertexSubset(n, out.size(), out.s);
+}
+
+
+
 //cond function that always returns true
 inline bool cond_true (intT d) { return 1; }
 
@@ -182,11 +379,13 @@ int parallel_main(int argc, char* argv[]) {
   bool symmetric = P.getOptionValue("-s");
   bool compressed = P.getOptionValue("-c");
   bool binary = P.getOptionValue("-b");
+  bool mmap = P.getOptionValue("-m");
+  cout << "mmap = " << mmap << endl;
   long rounds = P.getOptionLongValue("-rounds",3);
   if (compressed) {
     if (symmetric) {
       graph<compressedSymmetricVertex> G =
-        readCompressedGraph<compressedSymmetricVertex>(iFile,symmetric); //symmetric graph
+        readCompressedGraph<compressedSymmetricVertex>(iFile,symmetric,mmap); //symmetric graph
       Compute(G,P);
       for(int r=0;r<rounds;r++) {
         startTime();
@@ -196,7 +395,7 @@ int parallel_main(int argc, char* argv[]) {
       G.del();
     } else {
       graph<compressedAsymmetricVertex> G =
-        readCompressedGraph<compressedAsymmetricVertex>(iFile,symmetric); //asymmetric graph
+        readCompressedGraph<compressedAsymmetricVertex>(iFile,symmetric,mmap); //asymmetric graph
       Compute(G,P);
       if(G.transposed) G.transpose();
       for(int r=0;r<rounds;r++) {
@@ -210,7 +409,7 @@ int parallel_main(int argc, char* argv[]) {
   } else {
     if (symmetric) {
       graph<symmetricVertex> G =
-        readGraph<symmetricVertex>(iFile,compressed,symmetric,binary); //symmetric graph
+        readGraph<symmetricVertex>(iFile,compressed,symmetric,binary,mmap); //symmetric graph
       Compute(G,P);
       for(int r=0;r<rounds;r++) {
         startTime();
@@ -220,7 +419,7 @@ int parallel_main(int argc, char* argv[]) {
       G.del();
     } else {
       graph<asymmetricVertex> G =
-        readGraph<asymmetricVertex>(iFile,compressed,symmetric,binary); //asymmetric graph
+        readGraph<asymmetricVertex>(iFile,compressed,symmetric,binary,mmap); //asymmetric graph
       Compute(G,P);
       if(G.transposed) G.transpose();
       for(int r=0;r<rounds;r++) {

--- a/ligra/maybe.h
+++ b/ligra/maybe.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <tuple>
+
+using namespace std;
+
+template <class T>
+struct Maybe {
+  // pays an extra byte for NONE/SOME
+  // avoid Maybe<T>*---this is basically free otherwise
+  bool exists;
+  T t;
+  Maybe(const T& _t) : t(_t), exists(true) {}
+  Maybe() : exists(false) {}
+};
+
+inline const Maybe<tuple<uintE, uintE> > wrap(const uintE& l, const uintE& r) {
+  auto t = Maybe<tuple<uintE, uintE> >(make_tuple(l, r));
+  t.exists = (l != UINT_E_MAX) && (r != UINT_E_MAX);
+  return t;
+}
+
+template <class L, class R>
+inline const Maybe<tuple<L, R> > wrap(const L& l, const Maybe<R>& r) {
+  auto t = Maybe<tuple<L, R> >(make_tuple(l, getT(r)));
+  t.exists = r.exists;
+  return t;
+}
+
+template <class L, class R>
+inline Maybe<tuple<L, R> > wrap(const Maybe<L>& l, const R& r) {
+  auto t = Maybe<tuple<L, R> >(make_tuple(getT(l), r));
+  t.exists = l.exists;
+  return t;
+}
+
+template <class L, class R>
+inline Maybe<tuple<L, R> > wrap(const Maybe<L>& l, const Maybe<R>& r) {
+  auto t = Maybe<tuple<L, R> >(make_tuple(getT(l), getT(r)));
+  t.exists = l.exists && r.exists;
+  return t;
+}
+
+template <class T>
+inline bool isSome(const Maybe<T>& m) {
+  return m.exists;
+}
+
+template <class T>
+inline T getT(const Maybe<T>& m) {
+  return m.t;
+}

--- a/ligra/nibble-pd.h
+++ b/ligra/nibble-pd.h
@@ -32,7 +32,6 @@ typedef unsigned char uchar;
 #include <cmath>
 #include "parallel.h"
 #include "utils.h"
-#include "graph.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -79,11 +78,11 @@ long encode_nibbleval(uchar* start, long offset, long val) {
   return offset;
 }
 
-/** 
-  Decodes the first edge, which is specially sign encoded. 
+/**
+  Decodes the first edge, which is specially sign encoded.
 */
 inline uintE decode_first_edge(uchar* &start, long* location, uintE source) {
-  long val;  
+  long val;
   decode_val_nibblecode(start, location, val)
   long sign = val & 1;
   val >>= 1; // get rid of sign
@@ -94,7 +93,7 @@ inline uintE decode_first_edge(uchar* &start, long* location, uintE source) {
 }
 
 /*
-  Decodes an edge, but does not add back the 
+  Decodes an edge, but does not add back the
 */
 inline uintE decode_next_edge(uchar* &start, long* location) {
   long val;
@@ -103,12 +102,12 @@ inline uintE decode_next_edge(uchar* &start, long* location) {
 }
 
 /*
-  The main decoding work-horse. First eats the specially coded first 
+  The main decoding work-horse. First eats the specially coded first
   edge, and then eats the remaining |d-1| many edges that are normally
-  coded. 
+  coded.
 */
-template <class T, class F>
-  inline void decode(T t, F &f, uchar* edgeStart, const uintE &source, const uintT &degree) {  
+template <class T>
+  inline void decode(T t, uchar* edgeStart, const uintE &source, const uintT &degree, const bool par=true) {
   if (degree > 0) {
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
     uintE* pOffsets = (uintE*) edgeStart; //use beginning of edgeArray for offsets into edge list
@@ -116,40 +115,40 @@ template <class T, class F>
     //do first chunk
     long end = min<long>(PARALLEL_DEGREE,degree);
     long location = 0;
-    // Eat first edge, which is compressed specially 
+    // Eat first edge, which is compressed specially
 
     uintE startEdge = decode_first_edge(start,&location,source);
 
-    if(!t.srcTarg(f, source,startEdge,0)) return;
+    if(!t.srcTarg(source,startEdge,0)) return;
     for (uintE edgeID = 1; edgeID < end; edgeID++) {
       // Eat the next 'edge', which is a difference, and reconstruct edge.
       uintE edgeRead = decode_next_edge(start,&location);
       uintE edge = startEdge + edgeRead;
       startEdge = edge;
-      if(!t.srcTarg(f, source,startEdge,edgeID)) return;
+      if(!t.srcTarg(source,startEdge,edgeID)) return;
     }
     //do remaining chunks in parallel
-    parallel_for(long i=1;i<numChunks;i++) {
+    granular_for(i, 1, numChunks, par, {
       long o = i*PARALLEL_DEGREE;
       long end = min<long>(o+PARALLEL_DEGREE,degree);
-      // Eat first edge, which is compressed specially 
+      // Eat first edge, which is compressed specially
       long location = pOffsets[i-1];
       uintE startEdge = decode_first_edge(edgeStart,&location,source);
-      if(!t.srcTarg(f, source,startEdge,o)) end = 0;
+      if(!t.srcTarg(source,startEdge,o)) end = 0;
       for (uintE edgeID = o+1; edgeID < end; edgeID++) {
 	// Eat the next 'edge', which is a difference, and reconstruct edge.
 	uintE edgeRead = decode_next_edge(edgeStart,&location);
 	uintE edge = startEdge + edgeRead;
 	startEdge = edge;
-	if(!t.srcTarg(f, source,startEdge,edgeID)) break;
+	if(!t.srcTarg(source,startEdge,edgeID)) break;
       }
-    }   
+    });
   }
 }
 
 //decode edges for weighted graph
-template <class T, class F>
-  inline void decodeWgh(T t, F &f, uchar* edgeStart, const uintE &source,const uintT &degree) {
+template <class T>
+  inline void decodeWgh(T t, uchar* edgeStart, const uintE &source,const uintT &degree, const bool par=true) {
   if(degree > 0){
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
     uintE* pOffsets = (uintE*) edgeStart; //use beginning of edgeArray for offsets into edge list
@@ -157,40 +156,40 @@ template <class T, class F>
     //do first chunk
     long end = min<long>(PARALLEL_DEGREE,degree);
     long location = 0;
-    // Eat first edge, which is compressed specially 
+    // Eat first edge, which is compressed specially
     uintE startEdge = decode_first_edge(start,&location,source);
     intE weight = decode_first_edge(start,&location,0);
-    if(!t.srcTarg(f, source,startEdge,weight,0)) return;
+    if(!t.srcTarg(source,startEdge,weight,0)) return;
     for (uintE edgeID = 1; edgeID < end; edgeID++) {
       // Eat the next 'edge', which is a difference, and reconstruct edge.
       uintE edgeRead = decode_next_edge(start,&location);
       uintE edge = startEdge + edgeRead;
       startEdge = edge;
       intE weight = decode_first_edge(start,&location,0);
-      if(!t.srcTarg(f, source,startEdge,weight,edgeID)) return;
+      if(!t.srcTarg(source,startEdge,weight,edgeID)) return;
     }
     //do remaining chunks in parallel
-    parallel_for(long i=1;i<numChunks;i++) {
+    granular_for(i, 1, numChunks, par, {
       long o = i*PARALLEL_DEGREE;
       long end = min<long>(o+PARALLEL_DEGREE,degree);
       long location = pOffsets[i-1];
-      // Eat first edge, which is compressed specially 
+      // Eat first edge, which is compressed specially
       uintE startEdge = decode_first_edge(edgeStart,&location,source);
       intE weight = decode_first_edge(edgeStart,&location,0);
-      if(!t.srcTarg(f, source,startEdge, weight, o)) end = 0;
+      if(!t.srcTarg(source,startEdge, weight, o)) end = 0;
       for (uintE edgeID = o+1; edgeID < end; edgeID++) {
 	uintE edgeRead = decode_next_edge(edgeStart,&location);
 	uintE edge = startEdge + edgeRead;
 	startEdge = edge;
 	intE weight = decode_first_edge(edgeStart,&location,0);
-	if(!t.srcTarg(f, source, edge, weight, edgeID)) break;
+	if(!t.srcTarg(source, edge, weight, edgeID)) break;
       }
-    }
+    });
   }
 }
 
 /*
-  Takes: 
+  Takes:
     1. The edge array of chars to write into
     2. The current offset into this array
     3. The vertices degree
@@ -199,13 +198,13 @@ template <class T, class F>
   Returns:
     The new offset into the edge array
 */
-long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degree, 
+long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degree,
                                 uintE vertexNum, uintE *savedEdges) {
   if (degree > 0) {
     long startOffset = currentOffset;
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
     uintE* pOffsets = (uintE*) edgeArray; //use beginning of edgeArray for offsets into edge list
-    currentOffset += 2*(numChunks-1)*sizeof(uintE);      
+    currentOffset += 2*(numChunks-1)*sizeof(uintE);
     for(long i=0;i<numChunks;i++) {
       long o = i*PARALLEL_DEGREE;
       long end = min<long>(PARALLEL_DEGREE,degree-o);
@@ -223,8 +222,8 @@ long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degre
       currentOffset = encode_nibbleval(edgeArray, currentOffset, toCompress);
       long val;
       for (uintT edgeI=1; edgeI < end; edgeI++) {
-	// Store difference between cur and prev edge. 
-	uintE difference = myEdges[edgeI] - 
+	// Store difference between cur and prev edge.
+	uintE difference = myEdges[edgeI] -
 	  myEdges[edgeI - 1];
 	temp = currentOffset;
 	currentOffset = encode_nibbleval(edgeArray, currentOffset, difference);
@@ -236,7 +235,7 @@ long sequentialCompressEdgeSet(uchar *edgeArray, long currentOffset, uintT degre
 }
 
 /*
-  Compresses the edge set in parallel. 
+  Compresses the edge set in parallel.
 */
 uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE* Degrees) {
   cout << "parallel compressing, (n,m) = (" << n << "," << m << ")" << endl;
@@ -244,7 +243,7 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
   uintT *degrees = newA(uintT, n+1);
   long *charsUsedArr = newA(long, n);
   long *compressionStarts = newA(long, n+1);
-  {parallel_for(long i=0; i<n; i++) { 
+  {parallel_for(long i=0; i<n; i++) {
     degrees[i] = Degrees[i];
     charsUsedArr[i] = ceil((degrees[i] * 9) / 8) + 4;
   }}
@@ -254,14 +253,14 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
   uintE* iEdges = newA(uintE,toAlloc);
   {parallel_for(long i=0; i<n; i++) {
       edgePts[i] = iEdges+charsUsedArr[i];
-      long charsUsed = 
-	sequentialCompressEdgeSet((uchar *)(iEdges+charsUsedArr[i]), 
+      long charsUsed =
+	sequentialCompressEdgeSet((uchar *)(iEdges+charsUsedArr[i]),
 				  0, degrees[i+1]-degrees[i],
 				  i, edges + offsets[i]);
       // convert units from #1/2 bytes -> #bytes, round up to make it
       //byte-aligned
       charsUsed = (charsUsed+1) / 2;
-      charsUsedArr[i] = charsUsed; 
+      charsUsedArr[i] = charsUsed;
   }}
   long totalSpace = sequence::plusScan(charsUsedArr, compressionStarts, n);
   compressionStarts[n] = totalSpace; // in bytes
@@ -270,7 +269,7 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
 
   uchar *finalArr = newA(uchar, totalSpace);
   cout << "total space requested is : " << totalSpace << endl;
-  float avgBitsPerEdge = (float)totalSpace*8 / (float)m; 
+  float avgBitsPerEdge = (float)totalSpace*8 / (float)m;
   cout << "Average bits per edge: " << avgBitsPerEdge << endl;
 
   {parallel_for(long i=0; i<n; i++) {
@@ -291,7 +290,7 @@ uintE *parallelCompressEdges(uintE *edges, uintT *offsets, long n, long m, uintE
 typedef pair<uintE,intE> intEPair;
 
 /*
-  Takes: 
+  Takes:
     1. The edge array of chars to write into
     2. The current offset into this array
     3. The vertices degree
@@ -301,19 +300,19 @@ typedef pair<uintE,intE> intEPair;
     The new offset into the edge array
 */
 long sequentialCompressWeightedEdgeSet
-(uchar *edgeArray, long currentOffset, uintT degree, 
+(uchar *edgeArray, long currentOffset, uintT degree,
  uintE vertexNum, intEPair *savedEdges) {
   if (degree > 0) {
     long startOffset = currentOffset;
     long numChunks = 1+(degree-1)/PARALLEL_DEGREE;
     uintE* pOffsets = (uintE*) edgeArray; //use beginning of edgeArray for offsets into edge list
-    currentOffset += 2*(numChunks-1)*sizeof(uintE);      
+    currentOffset += 2*(numChunks-1)*sizeof(uintE);
     for(long i=0;i<numChunks;i++) {
       long o = i*PARALLEL_DEGREE;
       long end = min<long>(PARALLEL_DEGREE,degree-o);
       intEPair* myEdges = savedEdges + o;
       if(i>0) pOffsets[i-1] = currentOffset - startOffset;
-      
+
       // Compress the first edge whole, which is signed difference coded
       //target ID
       intE preCompress = myEdges[0].first - vertexNum;
@@ -327,22 +326,22 @@ long sequentialCompressWeightedEdgeSet
 
       //weight
       intE weight = myEdges[0].second;
-      if (weight < 0) sign = 0; else sign = 1; 
+      if (weight < 0) sign = 0; else sign = 1;
       toCompress = (abs(weight)<<1)|sign;
       currentOffset = encode_nibbleval(edgeArray, currentOffset, toCompress);
 
       for (uintT edgeI=1; edgeI < end; edgeI++) {
-	// Store difference between cur and prev edge. 
-	uintE difference = myEdges[edgeI].first - 
+	// Store difference between cur and prev edge.
+	uintE difference = myEdges[edgeI].first -
 	  myEdges[edgeI - 1].first;
-      
+
 	//compress difference
 	currentOffset = encode_nibbleval(edgeArray, currentOffset, difference);
-      
+
 	//compress weight
 
 	weight = myEdges[edgeI].second;
-	if (weight < 0) sign = 0; else sign = 1; 
+	if (weight < 0) sign = 0; else sign = 1;
 	toCompress = (abs(weight)<<1)|sign;
 	currentOffset = encode_nibbleval(edgeArray, currentOffset, toCompress);
       }
@@ -352,7 +351,7 @@ long sequentialCompressWeightedEdgeSet
 }
 
 /*
-  Compresses the weighted edge set in parallel. 
+  Compresses the weighted edge set in parallel.
 */
 uchar *parallelCompressWeightedEdges(intEPair *edges, uintT *offsets, long n, long m, uintE* Degrees) {
   cout << "parallel compressing, (n,m) = (" << n << "," << m << ")" << endl;
@@ -360,7 +359,7 @@ uchar *parallelCompressWeightedEdges(intEPair *edges, uintT *offsets, long n, lo
   uintT *degrees = newA(uintT, n+1);
   long *charsUsedArr = newA(long, n);
   long *compressionStarts = newA(long, n+1);
-  {parallel_for(long i=0; i<n; i++) { 
+  {parallel_for(long i=0; i<n; i++) {
     degrees[i] = Degrees[i];
     charsUsedArr[i] = 2*(ceil((degrees[i] * 9) / 8) + 4); //to change
   }}
@@ -370,8 +369,8 @@ uchar *parallelCompressWeightedEdges(intEPair *edges, uintT *offsets, long n, lo
   uintE* iEdges = newA(uintE,toAlloc);
   {parallel_for(long i=0; i<n; i++) {
     edgePts[i] = iEdges+charsUsedArr[i];
-    long charsUsed = 
-      sequentialCompressWeightedEdgeSet((uchar *)(iEdges+charsUsedArr[i]), 
+    long charsUsed =
+      sequentialCompressWeightedEdgeSet((uchar *)(iEdges+charsUsedArr[i]),
                 0, degrees[i+1]-degrees[i],
                 i, edges + offsets[i]);
     charsUsed = (charsUsed+1) / 2;
@@ -386,7 +385,7 @@ uchar *parallelCompressWeightedEdges(intEPair *edges, uintT *offsets, long n, lo
 
   uchar *finalArr = newA(uchar, totalSpace);
   cout << "total space requested is : " << totalSpace << endl;
-  float avgBitsPerEdge = (float)totalSpace*8 / (float)m; 
+  float avgBitsPerEdge = (float)totalSpace*8 / (float)m;
   cout << "Average bits per edge: " << avgBitsPerEdge << endl;
 
   {parallel_for(long i=0; i<n; i++) {

--- a/ligra/sequence.h
+++ b/ligra/sequence.h
@@ -1,0 +1,327 @@
+// This code is part of the Problem Based Benchmark Suite (PBBS)
+// Copyright (c) 2011-2016 Guy Blelloch and the PBBS team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights (to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#pragma once
+
+#include <iostream>
+#include <tuple>
+
+#include "index_map.h"
+
+namespace pbbs {
+  using namespace std;
+
+  constexpr const size_t _log_block_size = 12;
+  constexpr const size_t _block_size = (1 << _log_block_size);
+
+  inline size_t num_blocks(size_t n, size_t block_size) {
+    return (1 + ((n)-1)/(block_size));}
+
+  template <class F>
+  void sliced_for(size_t n, size_t block_size, const F& f) {
+    size_t l = num_blocks(n, block_size);
+    parallel_for_1 (size_t i = 0; i < l; i++) {
+      size_t s = i * block_size;
+      size_t e = min(s + block_size, n);
+      f(i, s, e);
+    }
+  }
+
+  template <class Index_Map, class F>
+  auto reduce_serial(Index_Map A, const F& f) -> typename Index_Map::T {
+    typename Index_Map::T r = A[0];
+    for (size_t j=1; j < A.size(); j++) {
+      r = f(r,A[j]);
+    }
+    return r;
+  }
+
+  template <class Index_Map, class F>
+  auto reduce(Index_Map A, const F& f, flags fl = no_flag)
+    -> typename Index_Map::T
+  {
+    using T = typename Index_Map::T;
+    size_t n = A.size();
+    size_t l = num_blocks(n, _block_size);
+    if (l <= 1 || (fl & fl_sequential))
+      return reduce_serial(A, f);
+    array_imap<T> Sums(l);
+    sliced_for (n, _block_size,
+		[&] (size_t i, size_t s, size_t e)
+		{ Sums[i] = reduce_serial(A.cut(s,e), f);});
+    T r = reduce_serial(Sums, f);
+    return r;
+  }
+
+  // sums I with + (can be any type with + defined)
+  template <class Index_Map>
+  auto reduce_add(Index_Map I, flags fl = no_flag)
+    -> typename Index_Map::T
+  {
+    using T = typename Index_Map::T;
+    auto add = [] (T x, T y) {return x + y;};
+    return reduce(I, add, fl);
+  }
+
+  const flags fl_scan_inclusive = (1 << 4);
+
+  // serial scan with combining function f and start value zero
+  // fl_scan_inclusive indicates it includes the current location
+  template <class Imap_In, class Imap_Out, class F>
+  auto scan_serial(Imap_In In, Imap_Out Out,
+		   const F& f, typename Imap_In::T zero,
+		   flags fl = no_flag)  -> typename Imap_In::T
+  {
+    using T = typename Imap_In::T;
+    T r = zero;
+    size_t n = In.size();
+    bool inclusive = fl & fl_scan_inclusive;
+    if (inclusive) {
+      for (size_t i = 0; i < n; i++) {
+	r = f(r,In[i]);
+	Out.update(i,r);
+      }
+    } else {
+      for (size_t i = 0; i < n; i++) {
+	T t = In[i];
+	Out.update(i,r);
+	r = f(r,t);
+      }
+    }
+    return r;
+  }
+
+  // parallel version of scan_serial -- see comments above
+  template <class Imap_In, class Imap_Out, class F>
+  auto scan(Imap_In In, Imap_Out Out,
+	    const F& f, typename Imap_In::T zero,
+	    flags fl = no_flag)  -> typename Imap_In::T
+  {
+    using T = typename Imap_In::T;
+    size_t n = In.size();
+    size_t l = num_blocks(n,_block_size);
+    if (l <= 2 || fl & fl_sequential)
+      return scan_serial(In, Out, f, zero, fl);
+    array_imap<T> Sums(l);
+    sliced_for (n, _block_size,
+		[&] (size_t i, size_t s, size_t e)
+		{ Sums[i] = reduce_serial(In.cut(s,e),f);});
+    T total = scan_serial(Sums, Sums, f, zero, 0);
+    sliced_for (n, _block_size,
+		[&] (size_t i, size_t s, size_t e)
+		{ scan_serial(In.cut(s,e), Out.cut(s,e), f, Sums[i], fl);});
+    return total;
+  }
+
+  template <class Imap_In, class Imap_Out>
+  auto scan_add(Imap_In In, Imap_Out Out, flags fl = no_flag)
+    -> typename Imap_In::T
+  {
+    using T = typename Imap_In::T;
+    auto add = [] (T x, T y) {return x + y;};
+    return scan(In, Out, add, (T) 0, fl);
+  }
+
+  template <class Index_Map>
+  size_t sum_flags_serial(Index_Map I) {
+    size_t r = 0;
+    for (size_t j=0; j < I.size(); j++) r += I[j];
+    return r;
+  }
+
+  template <class Imap_In, class Imap_Fl>
+  auto pack_serial(Imap_In In, Imap_Fl Fl)
+    -> array_imap<typename Imap_In::T> {
+    using T = typename Imap_In::T;
+    size_t n = In.size();
+    size_t m = sum_flags_serial(Fl);
+    T* Out = new_array_no_init<T>(m);
+    size_t k = 0;
+    for (size_t i=0; i < n; i++)
+      if (Fl[i]) assign_uninitialized(Out[k++], In[i]);
+    return make_array_imap(Out,m);
+  }
+
+  template <class Imap_In, class Imap_Fl>
+  void pack_serial_at(Imap_In In, typename Imap_In::T* Out, Imap_Fl Fl) {
+    size_t k = 0;
+    for (size_t i=0; i < In.size(); i++)
+      if (Fl[i]) Out[k++] = In[i];
+  }
+
+  template <class Imap_In, class Imap_Fl>
+  auto pack(Imap_In In, Imap_Fl Fl, flags fl = no_flag)
+    -> array_imap<typename Imap_In::T>
+  {
+    using T = typename Imap_In::T;
+    size_t n = In.size();
+    size_t l = num_blocks(n,_block_size);
+    if (l <= 1 || fl & fl_sequential)
+      return pack_serial(In, Fl);
+    array_imap<size_t> Sums(l);
+    sliced_for (n, _block_size,
+		[&] (size_t i, size_t s, size_t e)
+		{ Sums[i] = sum_flags_serial(Fl.cut(s,e));});
+    size_t m = scan_add(Sums, Sums);
+    T* Out = new_array_no_init<T>(m);
+    sliced_for (n, _block_size,
+		[&] (size_t i, size_t s, size_t e)
+		{ pack_serial_at(In.cut(s,e),
+				 Out + Sums[i],
+				 Fl.cut(s,e));});
+    return make_array_imap(Out,m);
+  }
+
+  template <class Idx_Type, class Imap_Fl>
+  array_imap<Idx_Type> pack_index(Imap_Fl Fl, flags fl = no_flag) {
+    auto identity = [] (size_t i) {return (Idx_Type) i;};
+    return pack(make_in_imap<Idx_Type>(Fl.size(),identity), Fl, fl);
+  }
+
+  template <class Idx_Type, class D, class F>
+  array_imap<tuple<Idx_Type, D> > pack_index_and_data(F& f, size_t size, flags fl = no_flag) {
+    auto identity = [&] (size_t i) {return make_tuple((Idx_Type)i, get<1>(f(i))); };
+    auto flgs_in = make_in_imap<bool>(size, [&] (size_t i) { return get<0>(f(i)); });
+    return pack(make_in_imap<tuple<Idx_Type, D> >(size,identity), flgs_in, fl);
+  }
+
+  template <class T, class PRED>
+  size_t filter_serial(T* In, T* Out, size_t n, PRED p) {
+    size_t k = 0;
+    for (size_t i = 0; i < n; i++)
+      if (p(In[i])) Out[k++] = In[i];
+    return k;
+  }
+
+  // template <class T, class PRED>
+  // size_t filter(T* In, T* Out, size_t n, PRED p, flags fl = no_flag) {
+  //   if (n < _F_BSIZE || fl & fl_sequential)
+  //     return filter_serial(In, Out, n, p);
+  //   bool *Flags = new_array_no_init<bool>(n);
+  //   parallel_for (size_t i=0; i < n; i++) Flags[i] = (bool) p(In[i]);
+  //   size_t  m = pack(In, Out, Flags, n);
+  //   free(Flags);
+  //   return m;
+  // }
+
+  // // Avoids reallocating the bool array
+  // template <class T, class PRED>
+  // size_t filter(T* In, T* Out, bool* Flags, size_t n, PRED p,
+  // 		flags fl = no_flag) {
+  //   if (n < _F_BSIZE || fl & fl_sequential)
+  //     return filter_serial(In, Out, n, p);
+  //   parallel_for (size_t i=0; i < n; i++) Flags[i] = (bool) p(In[i]);
+  //   size_t  m = pack(In, Out, Flags, n);
+  //   return m;
+  // }
+
+  // template <class T, class PRED>
+  // seq<T> filter(T* In, size_t n, PRED p, flags fl = no_flag) {
+  //   bool *Fl = new_array_no_init<bool>(n);
+  //   parallel_for (size_t i=0; i < n; i++) Fl[i] = (bool) p(In[i]);
+  //   seq<T> R = pack(In, Fl, n);
+  //   free(Fl);
+  //   return R;
+  // }
+
+  // // g maps indices to input elements
+  // // f maps indices to boolean flags
+  // template <class T, class G, class F>
+  // seq<T> filter(size_t n, G g, F f) {
+  //   bool *Fl = new_array_no_init<bool>(n);
+  //   parallel_for (size_t i=0; i < n; i++)
+  //     Fl[i] = (bool) f(i);
+  //   seq<T> R = pack<T>((T*) NULL, Fl, 0, n, g);
+  //   free(Fl);
+  //   return R;
+  // }
+
+   // Faster for a small number in output (about 40% or less)
+   // Destroys the input.   Does not need a bool array.
+   template <class T, class PRED>
+   size_t filterf(T* In, T* Out, size_t n, PRED p) {
+     size_t b = _F_BSIZE;
+     if (n < b)
+       return filter_serial(In, Out, n, p);
+     size_t l = nblocks(n, b);
+     b = nblocks(n, l);
+     size_t *Sums = new_array_no_init<size_t>(l + 1);
+     parallel_for_1 (size_t i = 0; i < l; i++) {
+       size_t s = i * b;
+       size_t e = min(s + b, n);
+       size_t k = s;
+       for (size_t j = s; j < e; j++)
+   	if (p(In[j])) In[k++] = In[j];
+       Sums[i] = k - s;
+     }
+     auto isums = array_imap<size_t>(Sums,l);
+     size_t m = scan_add(isums, isums);
+     Sums[l] = m;
+     parallel_for_1 (size_t i = 0; i < l; i++) {
+       T* I = In + i*b;
+       T* O = Out + Sums[i];
+       for (size_t j = 0; j < Sums[i+1]-Sums[i]; j++) {
+        O[j] = I[j];
+       }
+     }
+     free(Sums);
+     return m;
+   }
+
+   template <class T, class PRED>
+   size_t filterf_and_clear(T* In, T* Out, size_t n, PRED p, T& empty, size_t* Sums) {
+     size_t b = _F_BSIZE;
+     if (n < b)
+       return filter_serial(In, Out, n, p);
+     size_t l = nblocks(n, b);
+     b = nblocks(n, l);
+     parallel_for_1 (size_t i = 0; i < l; i++) {
+       size_t s = i * b;
+       size_t e = min(s + b, n);
+       size_t k = s;
+       for (size_t j = s; j < e; j++) {
+        if (p(In[j])) {
+          In[k] = In[j];
+          if (j > k) {
+            In[j] = empty;
+          }
+          k++;
+        }
+       }
+       Sums[i] = k - s;
+     }
+     auto isums = array_imap<size_t>(Sums,l);
+     size_t m = scan_add(isums, isums);
+     Sums[l] = m;
+     parallel_for_1 (size_t i = 0; i < l; i++) {
+       T* I = In + i*b;
+       T* O = Out + Sums[i];
+       for (size_t j = 0; j < Sums[i+1]-Sums[i]; j++) {
+        O[j] = I[j];
+        I[j] = empty;
+       }
+     }
+     return m;
+   }
+
+}
+

--- a/ligra/utils.h
+++ b/ligra/utils.h
@@ -1,5 +1,5 @@
 // This code is part of the project "Ligra: A Lightweight Graph Processing
-// Framework for Shared Memory", presented at Principles and Practice of 
+// Framework for Shared Memory", presented at Principles and Practice of
 // Parallel Programming, 2013.
 // Copyright (c) 2013 Julian Shun and Guy Blelloch
 //
@@ -31,12 +31,12 @@ using namespace std;
 
 // Needed to make frequent large allocations efficient with standard
 // malloc implementation.  Otherwise they are allocated directly from
-// vm. 
+// vm.
 #ifndef __APPLE__
 #include <malloc.h>
-//comment out the following two lines if running out of memory 
+//comment out the following two lines if running out of memory
 static int __ii =  mallopt(M_MMAP_MAX,0);
-static int __jj =  mallopt(M_TRIM_THRESHOLD,-1); 
+static int __jj =  mallopt(M_TRIM_THRESHOLD,-1);
 #endif
 
 #ifndef uint
@@ -62,6 +62,22 @@ template <class E>
 struct maxF { E operator() (const E& a, const E& b) const {return (a>b) ? a : b;}};
 
 struct nonMaxF{bool operator() (uintE &a) {return (a != UINT_E_MAX);}};
+
+// Sugar to pass in a single f and get a struct suitable for edgeMap.
+template <class F>
+struct EdgeMap_F {
+  F f;
+  EdgeMap_F(F &_f) : f(_f) {}
+  inline bool update(const uintE& s, const uintE& d) {
+    return f(s,d);
+  }
+
+  inline bool updateAtomic(const uintE& s, const uintE& d) {
+    return f(s,d);
+  }
+
+  inline bool cond(const uintE& d) const { return true; }
+};
 
 #define _SCAN_LOG_BSIZE 10
 #define _SCAN_BSIZE (1 << _SCAN_LOG_BSIZE)
@@ -112,31 +128,31 @@ namespace sequence {
 	}						\
   }
 
-  template <class OT, class intT, class F, class G> 
+  template <class OT, class intT, class F, class G>
   OT reduceSerial(intT s, intT e, F f, G g) {
     OT r = g(s);
     for (intT j=s+1; j < e; j++) r = f(r,g(j));
     return r;
   }
 
-  template <class OT, class intT, class F, class G> 
+  template <class OT, class intT, class F, class G>
   OT reduce(intT s, intT e, F f, G g) {
     intT l = nblocks(e-s, _SCAN_BSIZE);
     if (l <= 1) return reduceSerial<OT>(s, e, f , g);
     OT *Sums = newA(OT,l);
-    blocked_for (i, s, e, _SCAN_BSIZE, 
+    blocked_for (i, s, e, _SCAN_BSIZE,
 		 Sums[i] = reduceSerial<OT>(s, e, f, g););
     OT r = reduce<OT>((intT) 0, l, f, getA<OT,intT>(Sums));
     free(Sums);
     return r;
   }
 
-  template <class OT, class intT, class F> 
+  template <class OT, class intT, class F>
   OT reduce(OT* A, intT n, F f) {
     return reduce<OT>((intT)0,n,f,getA<OT,intT>(A));
   }
 
-  template <class OT, class intT> 
+  template <class OT, class intT>
   OT plusReduce(OT* A, intT n) {
     return reduce<OT>((intT)0,n,addF<OT>(),getA<OT,intT>(A));
   }
@@ -149,19 +165,19 @@ namespace sequence {
     return reduce<OT>((intT) 0,n,f,getAF<IT,OT,intT,G>(A,g));
   }
 
-  template <class intT> 
+  template <class intT>
   intT sum(bool *In, intT n) {
     return reduce<intT>((intT) 0, n, addF<intT>(), boolGetA<intT>(In));
   }
 
-  template <class ET, class intT, class F, class G> 
+  template <class ET, class intT, class F, class G>
   ET scanSerial(ET* Out, intT s, intT e, F f, G g, ET zero, bool inclusive, bool back) {
     ET r = zero;
     if (inclusive) {
       if (back) for (intT i = e-1; i >= s; i--) Out[i] = r = f(r,g(i));
       else for (intT i = s; i < e; i++) Out[i] = r = f(r,g(i));
     } else {
-      if (back) 
+      if (back)
 	for (intT i = e-1; i >= s; i--) {
 	  ET t = g(i);
 	  Out[i] = r;
@@ -177,46 +193,46 @@ namespace sequence {
     return r;
   }
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   ET scanSerial(ET *In, ET* Out, intT n, F f, ET zero) {
     return scanSerial(Out, (intT) 0, n, f, getA<ET,intT>(In), zero, false, false);
   }
 
   // back indicates it runs in reverse direction
-  template <class ET, class intT, class F, class G> 
+  template <class ET, class intT, class F, class G>
   ET scan(ET* Out, intT s, intT e, F f, G g,  ET zero, bool inclusive, bool back) {
     intT n = e-s;
     intT l = nblocks(n,_SCAN_BSIZE);
     if (l <= 2) return scanSerial(Out, s, e, f, g, zero, inclusive, back);
     ET *Sums = newA(ET,nblocks(n,_SCAN_BSIZE));
-    blocked_for (i, s, e, _SCAN_BSIZE, 
+    blocked_for (i, s, e, _SCAN_BSIZE,
 		 Sums[i] = reduceSerial<ET>(s, e, f, g););
     ET total = scan(Sums, (intT) 0, l, f, getA<ET,intT>(Sums), zero, false, back);
-    blocked_for (i, s, e, _SCAN_BSIZE, 
+    blocked_for (i, s, e, _SCAN_BSIZE,
 		 scanSerial(Out, s, e, f, g, Sums[i], inclusive, back););
     free(Sums);
     return total;
   }
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   ET scan(ET *In, ET* Out, intT n, F f, ET zero) {
     return scan(Out, (intT) 0, n, f, getA<ET,intT>(In), zero, false, false);}
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   ET scanI(ET *In, ET* Out, intT n, F f, ET zero) {
     return scan(Out, (intT) 0, n, f, getA<ET,intT>(In), zero, true, false);}
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   ET scanBack(ET *In, ET* Out, intT n, F f, ET zero) {
     return scan(Out, (intT) 0, n, f, getA<ET,intT>(In), zero, false, true);}
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   ET scanIBack(ET *In, ET* Out, intT n, F f, ET zero) {
     return scan(Out, (intT) 0, n, f, getA<ET,intT>(In), zero, true, true);}
 
-  template <class ET, class intT> 
+  template <class ET, class intT>
   ET plusScan(ET *In, ET* Out, intT n) {
-    return scan(Out, (intT) 0, n, addF<ET>(), getA<ET,intT>(In), 
+    return scan(Out, (intT) 0, n, addF<ET>(), getA<ET,intT>(In),
 		(ET) 0, false, false);}
 
 #define _F_BSIZE (2*_SCAN_BSIZE)
@@ -240,7 +256,7 @@ namespace sequence {
     return r;
   }
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   _seq<ET> packSerial(ET* Out, bool* Fl, intT s, intT e, F f) {
     if (Out == NULL) {
       intT m = sumFlagsSerial(Fl+s, e-s);
@@ -251,7 +267,7 @@ namespace sequence {
     return _seq<ET>(Out,k);
   }
 
-  template <class ET, class intT, class F> 
+  template <class ET, class intT, class F>
   _seq<ET> pack(ET* Out, bool* Fl, intT s, intT e, F f) {
     intT l = nblocks(e-s, _F_BSIZE);
     if (l <= 1) return packSerial(Out, Fl, s, e, f);
@@ -264,7 +280,7 @@ namespace sequence {
     return _seq<ET>(Out,m);
   }
 
-  template <class ET, class intT> 
+  template <class ET, class intT>
   intT pack(ET* In, ET* Out, bool* Fl, intT n) {
     return pack(Out, Fl, (intT) 0, n, getA<ET,intT>(In)).n;}
 
@@ -273,14 +289,21 @@ namespace sequence {
     return pack((intT *) NULL, Fl, (intT) 0, n, identityF<intT>());
   }
 
-  template <class ET, class intT, class PRED> 
-  intT filter(ET* In, ET* Out, intT n, PRED p) {
-    bool *Fl = newA(bool,n);
+  template <class ET, class intT, class PRED>
+  intT filter(ET* In, ET* Out, bool* Fl, intT n, PRED p) {
     parallel_for (intT i=0; i < n; i++) Fl[i] = (bool) p(In[i]);
     intT  m = pack(In, Out, Fl, n);
+    return m;
+  }
+
+  template <class ET, class intT, class PRED>
+  intT filter(ET* In, ET* Out, intT n, PRED p) {
+    bool *Fl = newA(bool,n);
+    intT m = filter(In, Out, Fl, n, p);
     free(Fl);
     return m;
   }
+
 }
 
 template <class ET>
@@ -291,7 +314,7 @@ inline bool CAS(ET *ptr, ET oldv, ET newv) {
     return __sync_bool_compare_and_swap((int*)ptr, *((int*)&oldv), *((int*)&newv));
   } else if (sizeof(ET) == 8) {
     return __sync_bool_compare_and_swap((long*)ptr, *((long*)&oldv), *((long*)&newv));
-  } 
+  }
   else {
     std::cout << "CAS bad length : " << sizeof(ET) << std::endl;
     abort();
@@ -301,14 +324,14 @@ inline bool CAS(ET *ptr, ET oldv, ET newv) {
 template <class ET>
 inline bool writeMin(ET *a, ET b) {
   ET c; bool r=0;
-  do c = *a; 
+  do c = *a;
   while (c > b && !(r=CAS(a,c,b)));
   return r;
 }
 
 template <class ET>
 inline void writeAdd(ET *a, ET b) {
-  volatile ET newV, oldV; 
+  volatile ET newV, oldV;
   do {oldV = *a; newV = oldV + b;}
   while (!CAS(a, oldV, newV));
 }
@@ -336,10 +359,10 @@ inline ulong hashInt(ulong a) {
 //remove duplicate integers in [0,...,n-1]
 void remDuplicates(uintE* indices, uintE* flags, long m, long n) {
   //make flags for first time
-  if(flags == NULL) {flags = newA(uintE,n); 
+  if(flags == NULL) {flags = newA(uintE,n);
     {parallel_for(long i=0;i<n;i++) flags[i]=UINT_E_MAX;}}
   {parallel_for(uintE i=0;i<m;i++)
-      if(indices[i] != UINT_E_MAX && flags[indices[i]] == UINT_E_MAX) 
+      if(indices[i] != UINT_E_MAX && flags[indices[i]] == UINT_E_MAX)
 	CAS(&flags[indices[i]],(uintE)UINT_E_MAX,i);
   }
   //reset flags
@@ -353,4 +376,141 @@ void remDuplicates(uintE* indices, uintE* flags, long m, long n) {
     }
   }
 }
+
+#define granular_for(_i, _start, _end, _cond, _body) { \
+  if (_cond) { \
+    {parallel_for(size_t _i=_start; _i < _end; _i++) { \
+      _body \
+    }} \
+  } else { \
+    {for (size_t _i=_start; _i < _end; _i++) { \
+      _body \
+    }} \
+  } \
+  }
+
+namespace pbbs {
+
+  struct empty {};
+
+  typedef uint32_t flags;
+  const flags no_flag = 0;
+  const flags fl_sequential = 1;
+  const flags fl_debug = 2;
+  const flags fl_time = 4;
+
+  template<typename T>
+  inline void assign_uninitialized(T& a, const T& b) {
+    new (static_cast<void*>(std::addressof(a))) T(b);
+  }
+
+  template<typename T>
+  inline void move_uninitialized(T& a, const T& b) {
+    new (static_cast<void*>(std::addressof(a))) T(std::move(b));
+  }
+
+  // a 32-bit hash function
+  uint32_t hash32(uint32_t a) {
+    a = (a+0x7ed55d16) + (a<<12);
+    a = (a^0xc761c23c) ^ (a>>19);
+    a = (a+0x165667b1) + (a<<5);
+    a = (a+0xd3a2646c) ^ (a<<9);
+    a = (a+0xfd7046c5) + (a<<3);
+    a = (a^0xb55a4f09) ^ (a>>16);
+    return a;
+  }
+
+  // from numerical recipes
+  uint64_t hash64(uint64_t u )
+  {
+    uint64_t v = u * 3935559000370003845 + 2691343689449507681;
+    v ^= v >> 21;
+    v ^= v << 37;
+    v ^= v >>  4;
+    v *= 4768777513237032717;
+    v ^= v << 20;
+    v ^= v >> 41;
+    v ^= v <<  5;
+    return v;
+  }
+
+  // Does not initialize the array
+  template<typename E>
+  E* new_array_no_init(size_t n, bool touch_pages=false) {
+    // pads in case user wants to allign with cache lines
+    size_t line_size = 64;
+    size_t bytes = ((n * sizeof(E))/line_size + 1)*line_size;
+    E* r = (E*) aligned_alloc(line_size, bytes);
+    if (r == NULL) {fprintf(stderr, "Cannot allocate space"); exit(1);}
+    // a hack to make sure tlb is full for huge pages
+    if (touch_pages)
+      parallel_for (size_t i = 0; i < bytes; i = i + (1 << 21))
+	((bool*) r)[i] = 0;
+    return r;
+  }
+
+  // Initializes in parallel
+  template<typename E>
+  E* new_array(size_t n) {
+    E* r = new_array_no_init<E>(n);
+    if (!std::is_trivially_default_constructible<E>::value) {
+      if (n > 2048)
+	parallel_for (size_t i = 0; i < n; i++) new ((void*) (r+i)) E;
+      else
+	for (size_t i = 0; i < n; i++) new ((void*) (r+i)) E;
+    }
+    return r;
+  }
+
+  // Destructs in parallel
+  template<typename E>
+  void delete_array(E* A, size_t n) {
+    // C++14 -- suppored by gnu C++11
+    if (!std::is_trivially_destructible<E>::value) {
+      if (n > 2048)
+	parallel_for (size_t i = 0; i < n; i++) A[i].~E();
+      else
+	for (size_t i = 0; i < n; i++) A[i].~E();
+    }
+    free(A);
+  }
+
+  template <typename ET>
+  inline bool CAS_GCC(ET *ptr, ET oldv, ET newv) {
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+  }
+
+  template <typename E, typename EV>
+  inline E fetch_and_add(E *a, EV b) {
+    volatile E newV, oldV;
+    do {oldV = *a; newV = oldV + b;}
+    while (!CAS_GCC(a, oldV, newV));
+    return oldV;
+  }
+
+  template <typename E, typename EV>
+  inline void write_add(E *a, EV b) {
+    volatile E newV, oldV;
+    do {oldV = *a; newV = oldV + b;}
+    while (!CAS_GCC(a, oldV, newV));
+  }
+
+  template <typename ET, typename F>
+  inline bool write_min(ET *a, ET b, F less) {
+    ET c; bool r=0;
+    do c = *a;
+    while (less(b,c) && !(r=CAS_GCC(a,c,b)));
+    return r;
+  }
+
+  // returns the log base 2 rounded up (works on ints or longs or unsigned versions)
+  template <class T>
+  static int log2_up(T i) {
+    int a=0;
+    T b=i-1;
+    while (b > 0) {b = b >> 1; a++;}
+    return a;
+  }
+}
+
 #endif

--- a/ligra/vertex.h
+++ b/ligra/vertex.h
@@ -4,100 +4,199 @@
 using namespace std;
 
 namespace decode_uncompressed {
-  template <class V, class F>
-  inline void decodeInNghBreakEarly(V* v, long i, bool* vertexSubset, F &f, bool* next, bool parallel = 0) {
+
+  // Used by edgeMapDense. Callers ensure cond(v_id). For each vertex, decode
+  // its in-edges, and check to see whether this neighbor is in the current
+  // frontier, calling update if it is. If processing the edges sequentially,
+  // break once !cond(v_id).
+  template <class vertex, class F, class G, class VS>
+  inline void decodeInNghBreakEarly(vertex* v, long v_id, VS& vertexSubset, F &f, G &g, bool parallel = 0) {
     uintE d = v->getInDegree();
     if (!parallel || d < 1000) {
-      for (uintE j=0; j<d; j++) {
+      for (size_t j=0; j<d; j++) {
         uintE ngh = v->getInNeighbor(j);
+        if (vertexSubset.isIn(ngh)) {
 #ifndef WEIGHTED
-        if (vertexSubset[ngh] && f.update(ngh,i))
+          auto m = f.update(ngh, v_id);
 #else
-        if (vertexSubset[ngh] && f.update(ngh,i,v->getInWeight(j)))
+          auto m = f.update(ngh, v_id, v->getInWeight(j));
 #endif
-          next[i] = 1;
-        if(!f.cond(i)) break;
+          g(v_id, m);
+        }
+        if(!f.cond(v_id)) break;
       }
     } else {
-      parallel_for(uintE j=0; j<d; j++) {
+      parallel_for(size_t j=0; j<d; j++) {
         uintE ngh = v->getInNeighbor(j);
+        if (vertexSubset.isIn(ngh)) {
 #ifndef WEIGHTED
-        if (vertexSubset[ngh] && f.updateAtomic(ngh,i))
+          auto m = f.update(ngh, v_id);
 #else
-        if (vertexSubset[ngh] && f.updateAtomic(ngh,i,v->getInWeight(j)))
+          auto m = f.update(ngh, v_id, v->getInWeight(j));
 #endif
-          next[i] = 1;
+          g(v_id, m);
+        }
       }
     }
   }
 
-  template <class V, class F>
-  inline void decodeOutNgh(V* v, long i, bool* vertexSubset, F &f, bool* next) {
+  // Used by edgeMapDenseForward. For each out-neighbor satisfying cond, call
+  // updateAtomic.
+  template <class V, class F, class G>
+  inline void decodeOutNgh(V* v, long i, F &f, G &g) {
     uintE d = v->getOutDegree();
-    if(d < 1000) {
-      for(uintE j=0; j<d; j++) {
-        uintE ngh = v->getOutNeighbor(j);
+    granular_for(j, 0, d, (d > 1000), {
+      uintE ngh = v->getOutNeighbor(j);
+      if (f.cond(ngh)) {
 #ifndef WEIGHTED
-        if (f.cond(ngh) && f.updateAtomic(i,ngh))
-#else 
-        if (f.cond(ngh) && f.updateAtomic(i,ngh,v->getOutWeight(j))) 
-#endif
-          next[ngh] = 1;
-      }
-    } else {
-      parallel_for(uintE j=0; j<d; j++) {
-        uintE ngh = v->getOutNeighbor(j);
-#ifndef WEIGHTED
-        if (f.cond(ngh) && f.updateAtomic(i,ngh)) 
+      auto m = f.updateAtomic(i,ngh);
 #else
-          if (f.cond(ngh) && f.updateAtomic(i,ngh,v->getOutWeight(j)))
+      auto m = f.updateAtomic(i,ngh,v->getOutWeight(j));
 #endif
-        next[ngh] = 1;
+        g(ngh, m);
       }
+    });
+  }
+
+  // Used by edgeMapSparse. For each out-neighbor satisfying cond, call
+  // updateAtomic.
+  template <class V, class F, class G>
+  inline void decodeOutNghSparse(V* v, long i, uintT o, F &f, G &g) {
+    uintE d = v->getOutDegree();
+    granular_for(j, 0, d, (d > 1000), {
+      uintE ngh = v->getOutNeighbor(j);
+      if (f.cond(ngh)) {
+#ifndef WEIGHTED
+        auto m = f.updateAtomic(i, ngh);
+#else
+        auto m = f.updateAtomic(i, ngh, v->getOutWeight(j));
+#endif
+        g(ngh, o+j, m);
+      } else {
+        g(ngh, o+j);
+      }
+    });
+  }
+
+  // Used by edgeMapSparse_no_filter. Sequentially decode the out-neighbors,
+  // and compactly write all neighbors satisfying g().
+  template <class V, class F, class G>
+  inline size_t decodeOutNghSparseSeq(V* v, long i, uintT o, F &f, G &g) {
+    uintE d = v->getOutDegree();
+    size_t k = 0;
+    for (size_t j=0; j<d; j++) {
+      uintE ngh = v->getOutNeighbor(j);
+      if (f.cond(ngh)) {
+#ifndef WEIGHTED
+        auto m = f.updateAtomic(i, ngh);
+#else
+        auto m = f.updateAtomic(i, ngh, v->getOutWeight(j));
+#endif
+        bool wrote = g(ngh, o+k, m);
+        if (wrote) { k++; }
+      }
+    }
+    return k;
+  }
+
+  // Decode the out-neighbors of v, and return the number of neighbors
+  // that satisfy f.
+  template <class V, class F>
+  inline size_t countOutNgh(V* v, long vtx_id, F& f) {
+    uintE d = v->getOutDegree();
+    if (d < 2000) {
+      size_t ct = 0;
+      for (size_t i=0; i<d; i++) {
+        uintE ngh = v->getOutNeighbor(i);
+#ifndef WEIGHTED
+        if (f(vtx_id, ngh))
+#else
+        if (f(vtx_id, ngh, v->getOutWeight(i)))
+#endif
+          ct++;
+      }
+      return ct;
+    } else {
+      size_t b_size = 2000;
+      size_t blocks = 1 + ((d-1)/b_size);
+      auto cts = array_imap<uintE>(blocks, [&] (size_t i) { return 0; });
+      parallel_for_1(size_t i=0; i<blocks; i++) {
+        size_t s = b_size*i;
+        size_t e = std::min(s + b_size, (size_t)d);
+        uintE ct = 0;
+        for (size_t j = s; j < e; j++) {
+          uintE ngh = v->getOutNeighbor(j);
+#ifndef WEIGHTED
+          if (f(vtx_id, ngh))
+#else
+          if (f(vtx_id, ngh, v->getOutNeighbor(j)))
+#endif
+            ct++;
+        }
+        cts[i] = ct;
+      }
+      size_t count = 0;
+      return pbbs::reduce_add(cts);
     }
   }
 
-  template <class V, class F>
-  inline void decodeOutNghSparse(V* v, long i, uintT o, F &f, uintE* outEdges) {
+  // Decode the out-neighbors of v. Apply f(src, ngh) and store the result
+  // using g.
+  template <class V, class E, class F, class G>
+  inline void copyOutNgh(V* v, long src, uintT o, F& f, G& g) {
     uintE d = v->getOutDegree();
-    if(d < 1000) {
-      for (uintE j=0; j < d; j++) {
-        uintE ngh = v->getOutNeighbor(j);
-#ifndef WEIGHTED
-        if(f.cond(ngh) && f.updateAtomic(i,ngh)) 
+    granular_for(j, 0, d, (d > 1000), {
+      uintE ngh = v->getOutNeighbor(j);
+#ifdef WEIGHTED
+      E val = f(src, ngh, v->getOutWeight(j));
 #else
-        if(f.cond(ngh) && f.updateAtomic(i,ngh,v->getOutWeight(j)))
+      E val = f(src, ngh);
 #endif
-          outEdges[o+j] = ngh;
-        else outEdges[o+j] = UINT_E_MAX;
+      g(ngh, o+j, val);
+    });
+  }
+
+  // TODO(laxmand): Add support for weighted graphs.
+  template <class V, class Pred>
+  inline size_t packOutNgh(V* v, long vtx_id, Pred& p, bool* bits, uintE* tmp) {
+    uintE d = v->getOutDegree();
+    if (d < 5000) {
+      size_t k = 0;
+      for (size_t i=0; i<d; i++) {
+        uintE ngh = v->getOutNeighbor(i);
+        if (p(vtx_id, ngh)) {
+          v->setOutNeighbor(k, ngh);
+          k++;
+        }
       }
+      v->setOutDegree(k);
+      return k;
     } else {
-      parallel_for (uintE j=0; j < d; j++) {
-        uintE ngh = v->getOutNeighbor(j);
-#ifndef WEIGHTED
-        if(f.cond(ngh) && f.updateAtomic(i,ngh)) 
-#else
-        if(f.cond(ngh) && f.updateAtomic(i,ngh,v->getOutWeight(j)))
-#endif
-          outEdges[o+j] = ngh;
-        else outEdges[o+j] = UINT_E_MAX;
+      parallel_for(size_t i=0; i<d; i++) {
+        uintE ngh = v->getOutNeighbor(i);
+        tmp[i] = ngh;
+        bits[i] = p(vtx_id, ngh);
       }
+      size_t k = sequence::pack(tmp, v->getOutNeighbors(), bits, d);
+      v->setOutDegree(k);
+      return k;
     }
   }
+
 }
 
 struct symmetricVertex {
 #ifndef WEIGHTED
   uintE* neighbors;
-#else 
+#else
   intE* neighbors;
 #endif
   uintT degree;
   void del() {free(neighbors); }
 #ifndef WEIGHTED
-symmetricVertex(uintE* n, uintT d) 
-#else 
-symmetricVertex(intE* n, uintT d) 
+symmetricVertex(uintE* n, uintT d)
+#else
+symmetricVertex(intE* n, uintT d)
 #endif
 : neighbors(n), degree(d) {}
 #ifndef WEIGHTED
@@ -105,6 +204,8 @@ symmetricVertex(intE* n, uintT d)
   uintE* getOutNeighbors () { return neighbors; }
   uintE getInNeighbor(uintT j) { return neighbors[j]; }
   uintE getOutNeighbor(uintT j) { return neighbors[j]; }
+  void setInNeighbor(uintT j, uintE ngh) { neighbors[j] = ngh; }
+  void setOutNeighbor(uintT j, uintE ngh) { neighbors[j] = ngh; }
   void setInNeighbors(uintE* _i) { neighbors = _i; }
   void setOutNeighbors(uintE* _i) { neighbors = _i; }
 #else
@@ -116,6 +217,10 @@ symmetricVertex(intE* n, uintT d)
   intE getOutNeighbor(intT j) { return neighbors[2*j]; }
   intE getInWeight(intT j) { return neighbors[2*j+1]; }
   intE getOutWeight(intT j) { return neighbors[2*j+1]; }
+  void setInNeighbor(uintT j, uintE ngh) { neighbors[2*j] = ngh; }
+  void setOutNeighbor(uintT j, uintE ngh) { neighbors[2*j] = ngh; }
+  void setInWeight(uintT j, intE wgh) { neighbors[2*j+1] = wgh; }
+  void setOutWeight(uintT j, intE wgh) { neighbors[2*j+1] = wgh; }
   void setInNeighbors(intE* _i) { neighbors = _i; }
   void setOutNeighbors(intE* _i) { neighbors = _i; }
 #endif
@@ -126,20 +231,41 @@ symmetricVertex(intE* n, uintT d)
   void setOutDegree(uintT _d) { degree = _d; }
   void flipEdges() {}
 
-  template <class F>
-  inline void decodeInNghBreakEarly(long i, bool* vertexSubset, F &f, bool* next, bool parallel = 0) {
-    decode_uncompressed::decodeInNghBreakEarly<symmetricVertex, F>(this, i, vertexSubset, f, next, parallel);
+  template <class VS, class F, class G>
+  inline void decodeInNghBreakEarly(long v_id, VS& vertexSubset, F &f, G &g, bool parallel = 0) {
+    decode_uncompressed::decodeInNghBreakEarly<symmetricVertex, F, G, VS>(this, v_id, vertexSubset, f, g, parallel);
+  }
+
+  template <class F, class G>
+  inline void decodeOutNgh(long i, F &f, G& g) {
+     decode_uncompressed::decodeOutNgh<symmetricVertex, F, G>(this, i, f, g);
+  }
+
+  template <class F, class G>
+  inline void decodeOutNghSparse(long i, uintT o, F &f, G &g) {
+    decode_uncompressed::decodeOutNghSparse<symmetricVertex, F>(this, i, o, f, g);
+  }
+
+  template <class F, class G>
+  inline size_t decodeOutNghSparseSeq(long i, uintT o, F &f, G &g) {
+    return decode_uncompressed::decodeOutNghSparseSeq<symmetricVertex, F>(this, i, o, f, g);
+  }
+
+  template <class E, class F, class G>
+  inline void copyOutNgh(long i, uintT o, F& f, G& g) {
+    decode_uncompressed::copyOutNgh<symmetricVertex, E>(this, i, o, f, g);
   }
 
   template <class F>
-  inline void decodeOutNgh(long i, bool* vertexSubset, F &f, bool* next) {
-     decode_uncompressed::decodeOutNgh<symmetricVertex, F>(this, i, vertexSubset, f, next);
+  inline size_t countOutNgh(long i, F &f) {
+    return decode_uncompressed::countOutNgh<symmetricVertex, F>(this, i, f);
   }
 
   template <class F>
-  inline void decodeOutNghSparse(long i, uintT o, F &f, uintE* outEdges) {
-    decode_uncompressed::decodeOutNghSparse<symmetricVertex, F>(this, i, o, f, outEdges);
+  inline size_t packOutNgh(long i, F &f, bool* bits, uintE* tmp1, uintE* tmp2) {
+    return decode_uncompressed::packOutNgh<symmetricVertex, F>(this, i, f, bits, tmp1);
   }
+
 };
 
 struct asymmetricVertex {
@@ -152,9 +278,9 @@ struct asymmetricVertex {
   uintT inDegree;
   void del() {free(inNeighbors); free(outNeighbors);}
 #ifndef WEIGHTED
-asymmetricVertex(uintE* iN, uintE* oN, uintT id, uintT od) 
+asymmetricVertex(uintE* iN, uintE* oN, uintT id, uintT od)
 #else
-asymmetricVertex(intE* iN, intE* oN, uintT id, uintT od) 
+asymmetricVertex(intE* iN, intE* oN, uintT id, uintT od)
 #endif
 : inNeighbors(iN), outNeighbors(oN), inDegree(id), outDegree(od) {}
 #ifndef WEIGHTED
@@ -162,15 +288,21 @@ asymmetricVertex(intE* iN, intE* oN, uintT id, uintT od)
   uintE* getOutNeighbors () { return outNeighbors; }
   uintE getInNeighbor(uintT j) { return inNeighbors[j]; }
   uintE getOutNeighbor(uintT j) { return outNeighbors[j]; }
+  void setInNeighbor(uintT j, uintE ngh) { inNeighbors[j] = ngh; }
+  void setOutNeighbor(uintT j, uintE ngh) { outNeighbors[j] = ngh; }
   void setInNeighbors(uintE* _i) { inNeighbors = _i; }
   void setOutNeighbors(uintE* _i) { outNeighbors = _i; }
-#else 
+#else
   intE* getInNeighbors () { return inNeighbors; }
   intE* getOutNeighbors () { return outNeighbors; }
   intE getInNeighbor(uintT j) { return inNeighbors[2*j]; }
   intE getOutNeighbor(uintT j) { return outNeighbors[2*j]; }
   intE getInWeight(uintT j) { return inNeighbors[2*j+1]; }
   intE getOutWeight(uintT j) { return outNeighbors[2*j+1]; }
+  void setInNeighbor(uintT j, uintE ngh) { inNeighbors[2*j] = ngh; }
+  void setOutNeighbor(uintT j, uintE ngh) { outNeighbors[2*j] = ngh; }
+  void setInWeight(uintT j, uintE wgh) { inNeighbors[2*j+1] = wgh; }
+  void setOutWeight(uintT j, uintE wgh) { outNeighbors[2*j+1] = wgh; }
   void setInNeighbors(intE* _i) { inNeighbors = _i; }
   void setOutNeighbors(intE* _i) { outNeighbors = _i; }
 #endif
@@ -181,20 +313,41 @@ asymmetricVertex(intE* iN, intE* oN, uintT id, uintT od)
   void setOutDegree(uintT _d) { outDegree = _d; }
   void flipEdges() { swap(inNeighbors,outNeighbors); swap(inDegree,outDegree); }
 
-  template <class F>
-  inline void decodeInNghBreakEarly(long i, bool* vertexSubset, F &f, bool* next, bool parallel = 0) {
-    decode_uncompressed::decodeInNghBreakEarly<asymmetricVertex, F>(this, i, vertexSubset, f, next, parallel);
+  template <class VS, class F, class G>
+  inline void decodeInNghBreakEarly(long v_id, VS& vertexSubset, F &f, G &g, bool parallel = 0) {
+    decode_uncompressed::decodeInNghBreakEarly<asymmetricVertex, F, G, VS>(this, v_id, vertexSubset, f, g, parallel);
+  }
+
+  template <class F, class G>
+  inline void decodeOutNgh(long i, F &f, G &g) {
+    decode_uncompressed::decodeOutNgh<asymmetricVertex, F, G>(this, i, f, g);
+  }
+
+  template <class F, class G>
+  inline void decodeOutNghSparse(long i, uintT o, F &f, G &g) {
+    decode_uncompressed::decodeOutNghSparse<asymmetricVertex, F>(this, i, o, f, g);
+  }
+
+  template <class F, class G>
+  inline size_t decodeOutNghSparseSeq(long i, uintT o, F &f, G &g) {
+    return decode_uncompressed::decodeOutNghSparseSeq<asymmetricVertex, F>(this, i, o, f, g);
+  }
+
+  template <class E, class F, class G>
+  inline void copyOutNgh(long i, uintT o, F& f, G& g) {
+    decode_uncompressed::copyOutNgh<asymmetricVertex, E>(this, i, o, f, g);
   }
 
   template <class F>
-  inline void decodeOutNgh(long i, bool* vertexSubset, F &f, bool* next) {
-    decode_uncompressed::decodeOutNgh<asymmetricVertex, F>(this, i, vertexSubset, f, next);
+  inline size_t countOutNgh(long i, F &f) {
+    return decode_uncompressed::countOutNgh<asymmetricVertex, F>(this, i, f);
   }
 
   template <class F>
-  inline void decodeOutNghSparse(long i, uintT o, F &f, uintE* outEdges) {
-    decode_uncompressed::decodeOutNghSparse<asymmetricVertex, F>(this, i, o, f, outEdges);
+  inline size_t packOutNgh(long i, F &f, bool* bits, uintE* tmp1, uintE* tmp2) {
+    return decode_uncompressed::packOutNgh<asymmetricVertex, F>(this, i, f, bits, tmp1);
   }
+
 };
 
 #endif

--- a/ligra/vertexSubset.h
+++ b/ligra/vertexSubset.h
@@ -1,44 +1,216 @@
-#ifndef VERTEX_SUBSET_H
-#define VERTEX_SUBSET_H
+#pragma once
 
-//*****VERTEX OBJECT*****
-struct vertexSubset {
-  long n, m;
-  uintE* s;
-  bool* d;
-  bool isDense;
+#include <functional>
+#include <limits>
 
-  // make a singleton vertex in range of n
-vertexSubset(long _n, intE v) 
-: n(_n), m(1), d(NULL), isDense(0) {
-  s = newA(uintE,1);
-  s[0] = v;
-}
-  
-  //empty vertex set
-vertexSubset(long _n) : n(_n), m(0), d(NULL), s(NULL), isDense(0) {}
-  // make vertexSubset from array of vertex indices
-  // n is range, and m is size of array
-vertexSubset(long _n, long _m, uintE* indices) 
-: n(_n), m(_m), s(indices), d(NULL), isDense(0) {}
-  // make vertexSubset from boolean array, where n is range
-vertexSubset(long _n, bool* bits) 
-: n(_n), d(bits), s(NULL), isDense(1)  {
-  m = sequence::sum(bits,_n); }
-  // make vertexSubset from boolean array giving number of true values
-vertexSubset(long _n, long _m, bool* bits) 
-: n(_n), m(_m), s(NULL), d(bits), isDense(1)  {}
+#include "index_map.h"
+#include "maybe.h"
+#include "sequence.h"
 
-  // delete the contents
-  void del(){
+using namespace std;
+
+template <class data>
+struct vertexSubsetData {
+  using S = tuple<uintE, data>;
+  using D = tuple<bool, data>;
+
+  // An empty vertex set.
+  vertexSubsetData(size_t _n) : n(_n), m(0), d(NULL), s(NULL), isDense(0) { }
+
+  // A vertexSubset from array of vertex indices.
+  vertexSubsetData(long _n, long _m, S* indices)
+  : n(_n), m(_m), s(indices), d(NULL), isDense(0) { }
+
+  // A vertexSubset from boolean array giving number of true values.
+  vertexSubsetData(long _n, long _m, D* _d)
+  : n(_n), m(_m), s(NULL), d(_d), isDense(1) { }
+
+  // A vertexSubset from boolean array giving number of true values. Calculate
+  // number of nonzeros and store in m.
+  vertexSubsetData(long _n, D* _d)
+  : n(_n), s(NULL), d(_d), isDense(1) {
+    auto d_map = make_in_imap<size_t>(n, [&] (size_t i) { return (size_t)get<0>(_d[i]); });
+    m = pbbs::reduce_add(d_map);
+  }
+
+  vertexSubsetData()
+  : n(0), m(0), s(NULL), d(NULL), isDense(0) { }
+
+  void del() {
     if (d != NULL) free(d);
     if (s != NULL) free(s);
   }
+
+  // Sparse
+  inline uintE& vtx(const uintE& i) const { return std::get<0>(s[i]); }
+  inline data& vtxData(const uintE& i) const { return std::get<1>(s[i]); }
+  inline tuple<uintE, data> vtxAndData(const uintE& i) const { return s[i]; }
+
+  // Dense
+  inline bool isIn(const uintE& v) const { return std::get<0>(d[v]); }
+  inline data& ithData(const uintE& v) const { return std::get<1>(d[v]); }
+
+  // Returns (uintE) -> Maybe<tuple<vertex, vertex-data>>.
+  auto get_fn_repr() const {
+    std::function<Maybe<tuple<uintE, data>>(const uintE&)> fn;
+    if (isDense) {
+      fn = [&] (const uintE& v) -> Maybe<tuple<uintE, data>> {
+        auto ret = Maybe<tuple<uintE, data>>(make_tuple(v, std::get<1>(d[v])));
+        ret.exists = std::get<0>(d[v]);
+        return ret;
+      };
+    } else {
+      fn = [&] (const uintE& i) -> Maybe<tuple<uintE, data>> {
+        return Maybe<tuple<uintE, data>>(s[i]);
+      };
+    }
+    return fn;
+  }
+
+  long size() { return m; }
+  long numVertices() { return n; }
+
   long numRows() { return n; }
   long numNonzeros() { return m; }
-  bool isEmpty() { return m==0; }
 
-  // converts to dense but keeps sparse representation if there
+  bool isEmpty() { return m==0; }
+  bool dense() { return isDense; }
+
+  void toSparse() {
+    if (s == NULL && m > 0) {
+      auto f = make_in_imap<D>(n, [&] (size_t i) -> tuple<bool, data> { return d[i]; });
+      auto out = pbbs::pack_index_and_data<uintE, data>(f, n);
+      out.alloc = false;
+      s = out.s;
+      if (out.size() != m) {
+        cout << "bad stored value of m" << endl;
+        abort();
+      }
+    }
+    isDense = false;
+  }
+
+  // Convert to dense but keep sparse representation if it exists.
+  void toDense() {
+    if (d == NULL) {
+      d = newA(D, n);
+      {parallel_for(long i=0;i<n;i++) std::get<0>(d[i]) = false;}
+      {parallel_for(long i=0;i<m;i++)
+        d[std::get<0>(s[i])] = make_tuple(true, std::get<1>(s[i]));}
+    }
+    isDense = true;
+  }
+
+
+  S* s;
+  D* d;
+  size_t n, m;
+  bool isDense;
+};
+
+// Specialized version where data = pbbs::empty.
+template <>
+struct vertexSubsetData<pbbs::empty> {
+  using S = uintE;
+
+  // An empty vertex set.
+  vertexSubsetData<pbbs::empty>(size_t _n) : n(_n), m(0), d(NULL), s(NULL), isDense(0) {}
+
+  // A vertexSubset with a single vertex.
+  vertexSubsetData<pbbs::empty>(long _n, uintE v)
+  : n(_n), m(1), d(NULL), isDense(0) {
+    s = newA(uintE, 1);
+    s[0] = v;
+  }
+
+  // A vertexSubset from array of vertex indices.
+  vertexSubsetData<pbbs::empty>(long _n, long _m, S* indices)
+  : n(_n), m(_m), s(indices), d(NULL), isDense(0) {}
+
+  // A vertexSubset from array of vertex indices.
+  vertexSubsetData<pbbs::empty>(long _n, long _m, tuple<uintE, pbbs::empty>* indices)
+  : n(_n), m(_m), s((uintE*)indices), d(NULL), isDense(0) {}
+
+  // A vertexSubset from boolean array giving number of true values.
+  vertexSubsetData<pbbs::empty>(long _n, long _m, bool* _d)
+  : n(_n), m(_m), s(NULL), d(_d), isDense(1)  {}
+
+  // A vertexSubset from boolean array giving number of true values. Calculate
+  // number of nonzeros and store in m.
+  vertexSubsetData<pbbs::empty>(long _n, bool* _d)
+  : n(_n), s(NULL), d(_d), isDense(1) {
+    auto d_map = make_in_imap<size_t>(n, [&] (size_t i) { return _d[i]; });
+    auto f = [&] (size_t i, size_t j) { return i + j; };
+    m = pbbs::reduce(d_map, f);
+  }
+
+  // A vertexSubset from boolean array giving number of true values. Calculate
+  // number of nonzeros and store in m.
+ vertexSubsetData<pbbs::empty>(long _n, tuple<bool, pbbs::empty>* _d)
+  : n(_n), s(NULL), d((bool*)_d), isDense(1)  {
+    auto d_map = make_in_imap<size_t>(n, [&] (size_t i) { return get<0>(_d[i]); });
+    auto f = [&] (size_t i, size_t j) { return i + j; };
+    m = pbbs::reduce(d_map, f);
+  }
+
+  void del() {
+    if (d != NULL) free(d);
+    if (s != NULL) free(s);
+  }
+
+  // Sparse
+  inline uintE& vtx(const uintE& i) const { return s[i]; }
+  inline pbbs::empty vtxData(const uintE& i) const { return pbbs::empty(); }
+  inline tuple<uintE, pbbs::empty> vtxAndData(const uintE& i) const { return make_tuple(s[i], pbbs::empty()); }
+
+  // Dense
+  inline bool isIn(const uintE& v) const { return d[v]; }
+  inline pbbs::empty ithData(const uintE& v) const { return pbbs::empty(); }
+
+  // Returns (uintE) -> Maybe<tuple<vertex, vertex-data>>.
+  auto get_fn_repr() const {
+    std::function<Maybe<tuple<uintE, pbbs::empty>>(const uintE&)> fn;
+    if (isDense) {
+      fn = [&] (const uintE& v) -> Maybe<tuple<uintE, pbbs::empty>> {
+        auto ret = Maybe<tuple<uintE, pbbs::empty>>(make_tuple(v, pbbs::empty()));
+        ret.exists = d[v];
+        return ret;
+      };
+    } else {
+      fn = [&] (const uintE& i) -> Maybe<tuple<uintE, pbbs::empty>> {
+        return Maybe<tuple<uintE, pbbs::empty>>(make_tuple(s[i], pbbs::empty()));
+      };
+    }
+    return fn;
+  }
+
+  long size() { return m; }
+  long numVertices() { return n; }
+
+  long numRows() { return n; }
+  long numNonzeros() { return m; }
+
+  bool isEmpty() { return m==0; }
+  bool dense() { return isDense; }
+
+  void toSparse() {
+    if (s == NULL && m > 0) {
+      auto _d = d;
+      auto f = [&] (size_t i) { return _d[i]; };
+      auto f_in = make_in_imap<bool>(n, f);
+      auto out = pbbs::pack_index<uintE>(f_in);
+      out.alloc = false;
+      s = out.s;
+      if (out.size() != m) {
+        cout << "bad stored value of m" << endl;
+        cout << "out.size = " << out.size() << " m = " << m << " n = " << n << endl;
+        abort();
+      }
+    }
+    isDense = false;
+  }
+
+  // Converts to dense but keeps sparse representation if it exists.
   void toDense() {
     if (d == NULL) {
       d = newA(bool,n);
@@ -48,41 +220,10 @@ vertexSubset(long _n, long _m, bool* bits)
     isDense = true;
   }
 
-  // converts to sparse but keeps dense representation if there
-  void toSparse() {
-    if (s == NULL) {
-      _seq<uintE> R = sequence::packIndex<uintE>(d,n);
-      if (m != R.n) {
-	cout << "bad stored value of m" << endl; 
-	abort();
-      }
-      s = R.A;
-    }
-    isDense = false;
-  }
-  // check for equality
-  bool eq (vertexSubset& b) {
-    toDense();
-    b.toDense();
-    bool* c = newA(bool,n);
-    {parallel_for (long i=0; i<b.n; i++) 
-	c[i] = (d[i] != b.d[i]);}
-    bool equal = (sequence::sum(c,n) == 0);
-    free(c);
-    return equal;
-  }
-
-  void print() {
-    if (isDense) {
-      cout << "D:";
-      for (long i=0;i<n;i++) if (d[i]) cout << i << " ";
-      cout << endl;
-    } else {
-      cout << "S:";
-      for (long i=0; i<m; i++)	cout << s[i] << " ";
-      cout << endl;
-    }
-  }
+  S* s;
+  bool* d;
+  size_t n, m;
+  bool isDense;
 };
 
-#endif
+using vertexSubset = vertexSubsetData<pbbs::empty>;


### PR DESCRIPTION
Main changes:

- Require c++14 (c++1y works as well). Necessary for automatic return type deduction in edgeMap_utils.h
- Add support for vertexSubsets where vertices have an associated data value. type_traits lets us provided an implementation identical to the existing vertexSubset implementation when data = pbbs::empty.
- Add new edgeMaps: edgeMapFilter (count/pack-out neighbors satisfying a predicate) and edgeMapSparse_no_filter (optimized version of edgeMapSparse which writes proportional to the output size)
- Add applications and bucketing implementation from Julienne in apps/bucketing/ 

Implementation changes:
- Use type_traits ("gen" functions in edgeMap_utils.h) to inline code that writes to a different type of output based on the type of the data.
- Add a "par" flag (default to true) to decode/decodeWgh. This lets us decode sequentially even for -pd codes if necessary.

All existing codes compile without any modifications.

I tested BFS, Components and PageRank with these changes applied vs. the current master and saw no regressions.

