### PR TITLE
Fix update/updateAtomic in edgeMapDense. Clean up flags/no_output code.

### DIFF
--- a/apps/BC.C
+++ b/apps/BC.C
@@ -131,8 +131,8 @@ void Compute(graph<vertex>& GA, commandLine P) {
   //tranpose graph
   GA.transpose();
   for(long r=round-2;r>=0;r--) { //backwards phase
-    vertexSubset output = edgeMap(GA, Frontier, BC_Back_F(Dependencies,Visited));
-    output.del(); Frontier.del();
+    edgeMap(GA, Frontier, BC_Back_F(Dependencies,Visited), -1, no_output);
+    Frontier.del();
     Frontier = Levels[r]; //gets frontier from Levels array
     //vertex map to mark visited and update Dependencies scores
     vertexMap(Frontier,BC_Back_Vertex_F(Visited,Dependencies,inverseNumPaths));

--- a/apps/BellmanFord.C
+++ b/apps/BellmanFord.C
@@ -76,7 +76,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
       {parallel_for(long i=0;i<n;i++) ShortestPathLen[i] = -(INT_E_MAX/2);}
       break;
     }
-    vertexSubset output = edgeMap(GA, Frontier, BF_F(ShortestPathLen,Visited), GA.m/20, output_vs | dense_forward);
+    vertexSubset output = edgeMap(GA, Frontier, BF_F(ShortestPathLen,Visited), GA.m/20, dense_forward);
     vertexMap(output,BF_Vertex_F(Visited));
     Frontier.del();
     Frontier = output;

--- a/apps/BellmanFord.C
+++ b/apps/BellmanFord.C
@@ -76,7 +76,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
       {parallel_for(long i=0;i<n;i++) ShortestPathLen[i] = -(INT_E_MAX/2);}
       break;
     }
-    vertexSubset output = edgeMap(GA, Frontier, BF_F(ShortestPathLen,Visited), GA.m/20, DENSE_FORWARD);
+    vertexSubset output = edgeMap(GA, Frontier, BF_F(ShortestPathLen,Visited), GA.m/20, output_vs | dense_forward);
     vertexMap(output,BF_Vertex_F(Visited));
     Frontier.del();
     Frontier = output;

--- a/apps/CF.C
+++ b/apps/CF.C
@@ -122,7 +122,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
 
   for (int iter = 0; iter < numIter; iter++){
     //edgemap to accumulate error for each node
-    edgeMap(GA, Frontier, CF_Edge_F<vertex>(GA.V,latent_curr,error,K));
+    edgeMap(GA, Frontier, CF_Edge_F<vertex>(GA.V,latent_curr,error,K), -1, no_output);
 
 #ifdef COMPUTE_ERROR
     cout << "sum of squared error: " << sequence::plusReduce(squaredErrors,n)/2 << " for iter: " << iter << endl;

--- a/apps/KCore.C
+++ b/apps/KCore.C
@@ -96,8 +96,8 @@ void Compute(graph<vertex>& GA, commandLine P) {
         break;
       }
       else {
-	vertexSubset output = edgeMap(GA,toRemove,Update_Deg(Degrees));
-	toRemove.del(); output.del();
+	edgeMap(GA,toRemove,Update_Deg(Degrees), -1, no_output);
+	toRemove.del();
       }
     }
     if(Frontier.numNonzeros() == 0) { largestCore = k-1; break; }

--- a/apps/MIS.C
+++ b/apps/MIS.C
@@ -116,7 +116,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
   long round = 0;
   vertexSubset Frontier(n, frontier_data);
   while (!Frontier.isEmpty()) {
-    edgeMap(GA, Frontier, MIS_Update(flags));
+    edgeMap(GA, Frontier, MIS_Update(flags), -1, no_output);
     vertexSubset output = vertexFilter(Frontier, MIS_Filter(flags));
     Frontier.del();
     Frontier = output;

--- a/apps/PageRank.C
+++ b/apps/PageRank.C
@@ -84,7 +84,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
   
   long iter = 0;
   while(iter++ < maxIters) {
-    vertexSubset output = edgeMap(GA,Frontier,PR_F<vertex>(p_curr,p_next,GA.V),0);
+    edgeMap(GA,Frontier,PR_F<vertex>(p_curr,p_next,GA.V),0, no_output);
     vertexMap(Frontier,PR_Vertex_F(p_curr,p_next,damping,n));
     //compute L1-norm between p_curr and p_next
     {parallel_for(long i=0;i<n;i++) {
@@ -95,8 +95,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
     //reset p_curr
     vertexMap(Frontier,PR_Vertex_Reset(p_curr));
     swap(p_curr,p_next);
-    Frontier.del(); 
-    Frontier = output;
+    cout << "fsize = " << Frontier.m << endl;
   }
   Frontier.del(); free(p_curr); free(p_next); 
 }

--- a/apps/PageRank.C
+++ b/apps/PageRank.C
@@ -95,7 +95,6 @@ void Compute(graph<vertex>& GA, commandLine P) {
     //reset p_curr
     vertexMap(Frontier,PR_Vertex_Reset(p_curr));
     swap(p_curr,p_next);
-    cout << "fsize = " << Frontier.m << endl;
   }
   Frontier.del(); free(p_curr); free(p_next); 
 }

--- a/apps/PageRankDelta.C
+++ b/apps/PageRankDelta.C
@@ -111,7 +111,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
 
   long round = 0;
   while(round++ < maxIters) {
-    edgeMap(GA,Frontier,PR_F<vertex>(GA.V,Delta,nghSum),GA.m/20,dense_forward); // no_output
+    edgeMap(GA,Frontier,PR_F<vertex>(GA.V,Delta,nghSum),GA.m/20, no_output | dense_forward);
     vertexSubset active 
       = (round == 1) ? 
       vertexFilter(All,PR_Vertex_F_FirstRound(p,Delta,nghSum,damping,one_over_n,epsilon2)) :

--- a/apps/PageRankDelta.C
+++ b/apps/PageRankDelta.C
@@ -110,9 +110,8 @@ void Compute(graph<vertex>& GA, commandLine P) {
   vertexSubset All(n,n,all); //all vertices
 
   long round = 0;
-  while(round++ < maxIters){
-    vertexSubset output = edgeMap(GA,Frontier,PR_F<vertex>(GA.V,Delta,nghSum),GA.m/20,DENSE_FORWARD);
-    output.del();
+  while(round++ < maxIters) {
+    edgeMap(GA,Frontier,PR_F<vertex>(GA.V,Delta,nghSum),GA.m/20,dense_forward); // no_output
     vertexSubset active 
       = (round == 1) ? 
       vertexFilter(All,PR_Vertex_F_FirstRound(p,Delta,nghSum,damping,one_over_n,epsilon2)) :

--- a/apps/Triangle.C
+++ b/apps/Triangle.C
@@ -85,7 +85,7 @@ void Compute(graph<vertex>& GA, commandLine P) {
   vertexSubset Frontier(n,n,frontier); //frontier contains all vertices
 
   vertexMap(Frontier,initF<vertex>(GA.V,counts));
-  edgeMap(GA,Frontier,countF<vertex>(GA.V,counts));
+  edgeMap(GA,Frontier,countF<vertex>(GA.V,counts), -1, no_output);
   long count = sequence::plusReduce(counts,n);
   cout << "triangle count = " << count << endl;
   Frontier.del(); free(counts);

--- a/apps/bucketing/DeltaStepping.C
+++ b/apps/bucketing/DeltaStepping.C
@@ -67,7 +67,7 @@ void DeltaStepping(graph<vertex>& G, uintE src, uintE delta, size_t num_buckets=
     auto active = bkt.identifiers;
     // The output of the edgeMap is a vertexSubsetData<uintE> where the value
     // stored with each vertex is its original distance in this round
-    auto res = edgeMapData<uintE>(G, active, Visit_F(dists), G.m/20, output_vs | sparse_no_filter | dense_forward);
+    auto res = edgeMapData<uintE>(G, active, Visit_F(dists), G.m/20, sparse_no_filter | dense_forward);
     vertexMap(res, apply_f);
     b.update_buckets(res.get_fn_repr(), res.size());
     res.del(); active.del();

--- a/apps/bucketing/DeltaStepping.C
+++ b/apps/bucketing/DeltaStepping.C
@@ -67,8 +67,7 @@ void DeltaStepping(graph<vertex>& G, uintE src, uintE delta, size_t num_buckets=
     auto active = bkt.identifiers;
     // The output of the edgeMap is a vertexSubsetData<uintE> where the value
     // stored with each vertex is its original distance in this round
-    auto res = edgeMapData<uintE>(G, active, Visit_F(dists), G.m/20, DENSE_FORWARD,
-                                  output | sparse_no_filter);
+    auto res = edgeMapData<uintE>(G, active, Visit_F(dists), G.m/20, output_vs | sparse_no_filter | dense_forward);
     vertexMap(res, apply_f);
     b.update_buckets(res.get_fn_repr(), res.size());
     res.del(); active.del();

--- a/apps/bucketing/KCoreSerial.C
+++ b/apps/bucketing/KCoreSerial.C
@@ -83,7 +83,7 @@ array_imap<intT> KCore(graph<vertex>& G, bool printCores=false) {
   for (size_t i = 0; i < n; i++) {
     intT v = vert[i];  // Smallest degree vertex in the remaining graph.
     vs.s[0] = v;
-    edgeMap(G, vs, df, -1, DENSE, no_output);
+    edgeMap(G, vs, df, -1, dense_forward); // no_output
   }
   vs.del();
 

--- a/apps/bucketing/KCoreSerial.C
+++ b/apps/bucketing/KCoreSerial.C
@@ -83,7 +83,7 @@ array_imap<intT> KCore(graph<vertex>& G, bool printCores=false) {
   for (size_t i = 0; i < n; i++) {
     intT v = vert[i];  // Smallest degree vertex in the remaining graph.
     vs.s[0] = v;
-    edgeMap(G, vs, df, -1, dense_forward); // no_output
+    edgeMap(G, vs, df, -1, no_output | dense_forward);
   }
   vs.del();
 

--- a/apps/bucketing/SetCover.C
+++ b/apps/bucketing/SetCover.C
@@ -39,7 +39,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
     // 1. sets -> elements (Pack out sets and update their degree)
     auto pack_predicate = [&] (const uintE& u, const uintE& ngh) { return Elms[ngh] != COVERED; };
     auto pack_apply = [&] (uintE v, size_t ct) { D[v] = ct; };
-    auto packed_vtxs = edgeMapFilter(G, active, pack_predicate, output_vs | pack_edges);
+    auto packed_vtxs = edgeMapFilter(G, active, pack_predicate, pack_edges);
     vertexMap(packed_vtxs, pack_apply);
 
     // Calculate the sets which still have sufficient degree (degree >= threshold)
@@ -49,7 +49,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
     packed_vtxs.del();
 
     // 2. sets -> elements (writeMin to acquire neighboring elements)
-    edgeMap(G, still_active, Visit_Elms(Elms.s), -1, dense_forward);
+    edgeMap(G, still_active, Visit_Elms(Elms.s), -1, no_output | dense_forward);
 
     // 3. sets -> elements (count and add to cover if enough elms were won)
     const size_t low_threshold = std::max((size_t)ceil(pow(1.0+epsilon,cur_bkt-1)), (size_t)1);
@@ -72,7 +72,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
         else Elms[v] = UINT_E_MAX;
       } return false;
     };
-    edgeMap(G, still_active, EdgeMap_F<decltype(reset_f)>(reset_f), -1, dense_forward); // no_output
+    edgeMap(G, still_active, EdgeMap_F<decltype(reset_f)>(reset_f), -1, no_output | dense_forward);
 
     // Rebucket the active sets. Ignore those that joined the cover.
     active.toSparse();

--- a/apps/bucketing/SetCover.C
+++ b/apps/bucketing/SetCover.C
@@ -39,7 +39,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
     // 1. sets -> elements (Pack out sets and update their degree)
     auto pack_predicate = [&] (const uintE& u, const uintE& ngh) { return Elms[ngh] != COVERED; };
     auto pack_apply = [&] (uintE v, size_t ct) { D[v] = ct; };
-    auto packed_vtxs = edgeMapFilter(G, active, pack_predicate, output | pack_edges);
+    auto packed_vtxs = edgeMapFilter(G, active, pack_predicate, output_vs | pack_edges);
     vertexMap(packed_vtxs, pack_apply);
 
     // Calculate the sets which still have sufficient degree (degree >= threshold)
@@ -49,7 +49,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
     packed_vtxs.del();
 
     // 2. sets -> elements (writeMin to acquire neighboring elements)
-    edgeMap(G, still_active, Visit_Elms(Elms.s), -1, DENSE_FORWARD, no_output);
+    edgeMap(G, still_active, Visit_Elms(Elms.s), -1, dense_forward);
 
     // 3. sets -> elements (count and add to cover if enough elms were won)
     const size_t low_threshold = std::max((size_t)ceil(pow(1.0+epsilon,cur_bkt-1)), (size_t)1);
@@ -72,7 +72,7 @@ dyn_arr<uintE> SetCover(graph<vertex>& G, size_t num_buckets=128) {
         else Elms[v] = UINT_E_MAX;
       } return false;
     };
-    edgeMap(G, still_active, EdgeMap_F<decltype(reset_f)>(reset_f), -1, DENSE_FORWARD, no_output);
+    edgeMap(G, still_active, EdgeMap_F<decltype(reset_f)>(reset_f), -1, dense_forward); // no_output
 
     // Rebucket the active sets. Ignore those that joined the cover.
     active.toSparse();

--- a/apps/encoder.C
+++ b/apps/encoder.C
@@ -1,0 +1,1 @@
+../ligra/encoder.C

--- a/apps/localAlg/HeatKernel-Parallel.C
+++ b/apps/localAlg/HeatKernel-Parallel.C
@@ -163,8 +163,8 @@ void Compute(graph<vertex>& GA, commandLine P) {
 	x = new_x;
       }
       vertexMap(Frontier,Local_Update(x,r));
-      vertexSubset output = edgeMap(GA, Frontier, HK_Last_F<vertex>(x,r,GA.V));
-      Frontier.del(); output.del();
+      edgeMap(GA, Frontier, HK_Last_F<vertex>(x,r,GA.V), -1, no_output);
+      Frontier.del();
       j++;
       break;
     }

--- a/apps/localAlg/encoder.C
+++ b/apps/localAlg/encoder.C
@@ -1,0 +1,1 @@
+../../ligra/encoder.C

--- a/ligra/ligra.h
+++ b/ligra/ligra.h
@@ -45,74 +45,108 @@ using namespace std;
 
 //*****START FRAMEWORK*****
 
-//options to edgeMap for different versions of dense edgeMap (default is DENSE)
-enum options { DENSE, DENSE_FORWARD };
-
 typedef uint32_t flags;
-const flags output = 1;
-const flags no_output = 2;
-const flags pack_edges = 4;
-const flags sparse_no_filter = 8;
+const flags output_vs = 1;
+const flags pack_edges = 2;
+const flags sparse_no_filter = 4;
+const flags dense_forward = 8;
+const flags dense_parallel = 16;
+
 
 template <class data, class vertex, class VS, class F>
-tuple<bool, data>* edgeMapDense(graph<vertex> GA, VS& vertexSubset, F &f, bool parallel = 0) {
-  using D = tuple<bool, data>;
-  long numVertices = GA.n;
-  vertex *G = GA.V;
-  D* next = newA(D, numVertices);
-  auto g = get_emdense_gen<data>(next);
-  parallel_for (long v=0; v<numVertices; v++) {
-    std::get<0>(next[v]) = 0;
-    if (f.cond(v)) {
-      G[v].decodeInNghBreakEarly(v, vertexSubset, f, g, parallel);
-    }
-  }
-  return next;
-}
-
-template <class data, class vertex, class VS, class F>
-tuple<bool, data>* edgeMapDenseForward(graph<vertex> GA, VS& vertexSubset, F &f) {
+vertexSubsetData<data> edgeMapDense(graph<vertex> GA, VS& vertexSubset, F &f, const flags fl) {
   using D = tuple<bool, data>;
   long n = GA.n;
   vertex *G = GA.V;
-  D* next = newA(D, n);
-  auto g = get_emdense_forward_gen<data>(next);
-  parallel_for(long i=0;i<n;i++) { std::get<0>(next[i]) = 0; }
-  parallel_for (long i=0; i<n; i++) {
-    if (vertexSubset.isIn(i)) {
-      G[i].decodeOutNgh(i, f, g);
+  if (fl & output_vs) {
+    D* next = newA(D, n);
+    auto g = get_emdense_gen<data>(next);
+    parallel_for (long v=0; v<n; v++) {
+      std::get<0>(next[v]) = 0;
+      if (f.cond(v)) {
+        G[v].decodeInNghBreakEarly(v, vertexSubset, f, g, fl & dense_parallel);
+      }
     }
+    return vertexSubsetData<data>(n, next);
+  } else {
+    auto g = get_emdense_nooutput_gen<data>();
+    parallel_for (long v=0; v<n; v++) {
+      if (f.cond(v)) {
+        G[v].decodeInNghBreakEarly(v, vertexSubset, f, g, fl & dense_parallel);
+      }
+    }
+    return vertexSubsetData<data>(n);
   }
-  return next;
 }
 
-template <class data, class vertex, class vs, class F>
-pair<size_t, tuple<uintE, data>*> edgeMapSparse(vertex* frontierVertices, vs &indices,
-        uintT* degrees, uintT m, F &f) {
-  using S = tuple<uintE, data>;
-  uintT* offsets = degrees;
-  long outEdgeCount = sequence::plusScan(offsets, offsets, m);
-  S* outEdges = newA(S, outEdgeCount);
-
-  auto g = get_emsparse_gen<data>(outEdges);
-
-  parallel_for (size_t i = 0; i < m; i++) {
-    uintT v = indices.vtx(i), o = offsets[i];
-    vertex vert = frontierVertices[i];
-    vert.decodeOutNghSparse(v, o, f, g);
+template <class data, class vertex, class VS, class F>
+vertexSubsetData<data> edgeMapDenseForward(graph<vertex> GA, VS& vertexSubset, F &f, const flags fl) {
+  using D = tuple<bool, data>;
+  long n = GA.n;
+  vertex *G = GA.V;
+  if (fl & output_vs) {
+    D* next = newA(D, n);
+    auto g = get_emdense_forward_gen<data>(next);
+    parallel_for(long i=0;i<n;i++) { std::get<0>(next[i]) = 0; }
+    parallel_for (long i=0; i<n; i++) {
+      if (vertexSubset.isIn(i)) {
+        G[i].decodeOutNgh(i, f, g);
+      }
+    }
+    return vertexSubsetData<data>(n, next);
+  } else {
+    auto g = get_emdense_forward_nooutput_gen<data>();
+    parallel_for (long i=0; i<n; i++) {
+      if (vertexSubset.isIn(i)) {
+        G[i].decodeOutNgh(i, f, g);
+      }
+    }
+    return vertexSubsetData<data>(n);
   }
-  S* nextIndices = newA(S, outEdgeCount);
+}
 
-  auto p = [] (tuple<uintE, data>& v) { return std::get<0>(v) != UINT_E_MAX; };
-  size_t nextM = pbbs::filterf(outEdges, nextIndices, outEdgeCount, p);
-  free(outEdges);
-  return make_pair(nextM, nextIndices);
+template <class data, class vertex, class VS, class F>
+vertexSubsetData<data> edgeMapSparse(vertex* frontierVertices, VS& indices,
+        uintT* degrees, uintT m, F &f, const flags fl) {
+  using S = tuple<uintE, data>;
+  long n = indices.n;
+  S* outEdges;
+  long outEdgeCount = 0;
+
+  if (fl & output_vs) {
+    uintT* offsets = degrees;
+    outEdgeCount = sequence::plusScan(offsets, offsets, m);
+    outEdges = newA(S, outEdgeCount);
+    auto g = get_emsparse_gen<data>(outEdges);
+    parallel_for (size_t i = 0; i < m; i++) {
+      uintT v = indices.vtx(i), o = offsets[i];
+      vertex vert = frontierVertices[i];
+      vert.decodeOutNghSparse(v, o, f, g);
+    }
+  } else {
+    auto g = get_emsparse_nooutput_gen<data>();
+    parallel_for (size_t i = 0; i < m; i++) {
+      uintT v = indices.vtx(i);
+      vertex vert = frontierVertices[i];
+      vert.decodeOutNghSparse(v, 0, f, g);
+    }
+  }
+
+  if (fl & output_vs) {
+    S* nextIndices = newA(S, outEdgeCount);
+    auto p = [] (tuple<uintE, data>& v) { return std::get<0>(v) != UINT_E_MAX; };
+    size_t nextM = pbbs::filterf(outEdges, nextIndices, outEdgeCount, p);
+    free(outEdges);
+    return vertexSubsetData<data>(n, nextM, nextIndices);
+  } else {
+    return vertexSubsetData<data>(n);
+  }
 }
 
 // Decides on sparse or dense base on number of nonzeros in the active vertices.
 template <class data, class vertex, class VS, class F>
 vertexSubsetData<data> edgeMapData(const graph<vertex>& GA, VS &vs, F f,
-    intT threshold = -1, char option=DENSE, const flags& fl=output) {
+    intT threshold = -1, const flags& fl=output_vs) {
   long numVertices = GA.n, numEdges = GA.m, m = vs.numNonzeros();
   if(threshold == -1) threshold = numEdges/20; //default threshold
   vertex *G = GA.V;
@@ -136,66 +170,31 @@ vertexSubsetData<data> edgeMapData(const graph<vertex>& GA, VS &vs, F f,
   if (m + outDegrees > threshold) {
     vs.toDense();
     free(degrees); free(frontierVertices);
-    tuple<bool, data>* R = (option == DENSE_FORWARD) ?
-      edgeMapDenseForward<data, vertex, VS, F>(GA, vs, f) :
-      edgeMapDense<data, vertex, VS, F>(GA, vs, f, option);
-    vertexSubsetData<data> v1 = vertexSubsetData<data>(numVertices, R);
-    return v1;
+    return (fl & dense_forward) ?
+      edgeMapDenseForward<data, vertex, VS, F>(GA, vs, f, fl) :
+      edgeMapDense<data, vertex, VS, F>(GA, vs, f, fl);
   } else {
-    pair<size_t, tuple<uintE, data>*> R =
-      (fl & sparse_no_filter) ?
+    auto vs_out =
+      (fl & output_vs && fl & sparse_no_filter) ? // only call snof when we output
       edgeMapSparse_no_filter<data, vertex, VS, F>(frontierVertices, vs, degrees, vs.numNonzeros(), f) :
-      edgeMapSparse<data, vertex, VS, F>(frontierVertices, vs, degrees, vs.numNonzeros(), f);
+      edgeMapSparse<data, vertex, VS, F>(frontierVertices, vs, degrees, vs.numNonzeros(), f, fl);
     free(degrees); free(frontierVertices);
-    return vertexSubsetData<data>(numVertices, R.first, R.second);
+    return vs_out;
   }
 }
 
-// Version of edgeMap which produces no output.
-template <class outdata, class vertex, class VS, class F>
-vertexSubsetData<outdata> edgeMapNoOutput(graph<vertex> GA, VS &vs, F f,
-    intT threshold = -1, char option=DENSE, const flags& fl=output) {
-  long numVertices = GA.n, numEdges = GA.m, m = vs.numNonzeros();
-  if(threshold == -1) threshold = numEdges/20;
-  vertex *V = GA.V;
-  if (numVertices != vs.numRows()) {
-    cout << "edgeMap: Sizes Don't match" << endl;
-    abort();
-  }
-  if (vs.size() == 0) {
-    return vertexSubsetData<outdata>(numVertices);
-  }
-
-  vs.toSparse();
-  vertex* frontierVertices = newA(vertex,m);
-  {parallel_for (size_t i=0; i < m; i++) {
-    uintE v_id = vs.vtx(i);
-    vertex v = V[v_id];
-    frontierVertices[i] = v;
-  }}
-
-  edgeMapSparseNoOutput<outdata, vertex, VS, F>(frontierVertices, vs, vs.numNonzeros(), f);
-  free(frontierVertices);
-  return vertexSubsetData<outdata>(numVertices);
-}
-
-// Main edgeMap function, which determines which implementation to call based on
-// the flags provided by the user.
+// Regular edgeMap, where no extra data is stored per vertex.
 template <class vertex, class VS, class F>
 vertexSubset edgeMap(graph<vertex> GA, VS& vs, F f,
-    intT threshold = -1, char option=DENSE, const flags& fl=output) {
-  if (fl & no_output) {
-    return edgeMapNoOutput<pbbs::empty>(GA, vs, f, threshold, option, fl);
-  } else {
-    return edgeMapData<pbbs::empty>(GA, vs, f, threshold, option, fl);
-  }
+    intT threshold = -1, const flags& fl=output_vs) {
+  return edgeMapData<pbbs::empty>(GA, vs, f, threshold, fl);
 }
 
 // Packs out the adjacency lists of all vertex in vs. A neighbor, ngh, is kept
 // in the new adjacency list if p(ngh) is true.
 // Weighted graphs are not yet supported, but this should be easy to do.
 template <class vertex, class P>
-vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output) {
+vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output_vs) {
   using S = tuple<uintE, uintE>;
   vs.toSparse();
   vertex* G = GA.V; long m = vs.numNonzeros(); long n = vs.numRows();
@@ -209,14 +208,14 @@ vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, con
   });
   long outEdgeCount = pbbs::scan_add(degrees, degrees);
   S* outV;
-  if (fl & output) {
+  if (fl & output_vs) {
     outV = newA(S, vs.size());
   }
 
   bool* bits = newA(bool, outEdgeCount);
   uintE* tmp1 = newA(uintE, outEdgeCount);
   uintE* tmp2 = newA(uintE, outEdgeCount);
-  if (fl & output) {
+  if (fl & output_vs) {
     parallel_for (size_t i=0; i<m; i++) {
       uintE v = vs.vtx(i);
       size_t offset = degrees[i];
@@ -235,7 +234,7 @@ vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, con
     }
   }
   free(bits); free(tmp1); free(tmp2);
-  if (fl & output) {
+  if (fl & output_vs) {
     return vertexSubsetData<uintE>(n, m, outV);
   } else {
     return vertexSubsetData<uintE>(n);
@@ -243,7 +242,7 @@ vertexSubsetData<uintE> packEdges(graph<vertex>& GA, vertexSubset& vs, P& p, con
 }
 
 template <class vertex, class P>
-vertexSubsetData<uintE> edgeMapFilter(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output) {
+vertexSubsetData<uintE> edgeMapFilter(graph<vertex>& GA, vertexSubset& vs, P& p, const flags& fl=output_vs) {
   vs.toSparse();
   if (fl & pack_edges) {
     return packEdges<vertex, P>(GA, vs, p, fl);
@@ -254,10 +253,10 @@ vertexSubsetData<uintE> edgeMapFilter(graph<vertex>& GA, vertexSubset& vs, P& p,
     return vertexSubsetData<uintE>(n);
   }
   S* outV;
-  if (fl & output) {
+  if (fl & output_vs) {
     outV = newA(S, vs.size());
   }
-  if (fl & output) {
+  if (fl & output_vs) {
     parallel_for (size_t i=0; i<m; i++) {
       uintE v = vs.vtx(i);
       size_t ct = G[v].countOutNgh(v, p);
@@ -269,7 +268,7 @@ vertexSubsetData<uintE> edgeMapFilter(graph<vertex>& GA, vertexSubset& vs, P& p,
       size_t ct = G[v].countOutNgh(v, p);
     }
   }
-  if (fl & output) {
+  if (fl & output_vs) {
     return vertexSubsetData<uintE>(n, m, outV);
   } else {
     return vertexSubsetData<uintE>(n);

--- a/ligra/vertex.h
+++ b/ligra/vertex.h
@@ -30,9 +30,9 @@ namespace decode_uncompressed {
         uintE ngh = v->getInNeighbor(j);
         if (vertexSubset.isIn(ngh)) {
 #ifndef WEIGHTED
-          auto m = f.update(ngh, v_id);
+          auto m = f.updateAtomic(ngh, v_id);
 #else
-          auto m = f.update(ngh, v_id, v->getInWeight(j));
+          auto m = f.updateAtomic(ngh, v_id, v->getInWeight(j));
 #endif
           g(v_id, m);
         }


### PR DESCRIPTION
Hi Julian,

I committed a bug in the edgeMapDense code with the Julienne commit (if we're running in parallel, we should call updateAtomic). This commit fixes this bug.

This change also makes  dense_forward/dense_parallel part of the "flags" we recently added. One slightly confusing thing is that if you want to run dense_forward, you have to remember to also specify output_vs, otherwise the framework will assume you don't want to create the output vertexSubset and just return an empty subset.

This commit also adds no_output versions of edgeMapSparse/Dense/DenseForward by checking the output_vs flag in each call and using the right "gen" function to implement the write.