### PR TITLE
Fix memory leak and free mismatch

### DIFF
--- a/ligra/graph.h
+++ b/ligra/graph.h
@@ -72,7 +72,7 @@ graph(vertex* _V, long _n, long _m, Deletable* _D, uintE* _flags) : V(_V),
   void del() {
     if (flags != NULL) free(flags);
     D->del();
-    free(D);
+    delete D;
   }
 
   void transpose() {

--- a/ligra/ligra.h
+++ b/ligra/ligra.h
@@ -260,6 +260,7 @@ vertexSubsetData<data> edgeMapData(graph<vertex>& GA, VS &vs, F f,
   }
   if (!(fl & no_dense) && (m + outDegrees > threshold)) {
     vs.toDense();
+    free(degrees); free(frontierVertices);
     return (fl & dense_forward) ?
       edgeMapDenseForward<data, vertex, VS, F>(GA, vs, f, fl) :
       edgeMapDense<data, vertex, VS, F>(GA, vs, f, fl);


### PR DESCRIPTION
In [IO.h](https://github.com/jshun/ligra/blob/26dec8d0ee8d1f62012e5225bcd781424e7cec52/ligra/IO.h#L220) it could also cause memory leak but I respect the comment there and leave it unchanged.